### PR TITLE
Arabic M.U fix

### DIFF
--- a/ar/messages.po
+++ b/ar/messages.po
@@ -3964,7 +3964,7 @@ msgstr "انتقل إلى شركة جديدة"
 #: src/components/_layout/LayoutMenu.tsx:135
 #: src/components/_military/tournament/TournamentRegisterButton.tsx:135
 msgid "MU"
-msgstr "الوحدة العسكرية (MU)"
+msgstr "و.ع"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1202
 msgid "MU Application Accepted"


### PR DESCRIPTION
Fixed an issue with the MU string. The text placeholder was too small to display the full Arabic translation of "Military Unit," so it could not be used. Instead, "و.ع" was used as the Arabic equivalent