### PR TITLE
Fix German commander translation

### DIFF
--- a/de/messages.po
+++ b/de/messages.po
@@ -1403,7 +1403,7 @@ msgstr "Arkane Stiefel"
 
 #: src/components/_military/mu/MuMemberList.tsx:154
 msgid "Are you sure you want to demote this commander?"
-msgstr "Bist du sicher, dass du diesen Kommandanten degradieren möchtest?"
+msgstr "Bist du sicher, dass du diesen Kommandeur degradieren möchtest?"
 
 #: src/components/_user/worker/WorkerEditFormModal.tsx:102
 msgid "Are you sure you want to fire this worker?"
@@ -1423,7 +1423,7 @@ msgstr "Sind Sie sicher, dass Sie die Regierung verlassen wollen?"
 
 #: src/components/_military/mu/MuMemberList.tsx:147
 msgid "Are you sure you want to promote this member to commander?"
-msgstr "Bist du sicher, dass du dieses Mitglied zum Kommandanten befördern möchtest?"
+msgstr "Bist du sicher, dass du dieses Mitglied zum Kommandeur befördern möchtest?"
 
 #: src/pages/market/index.tsx:170
 msgid "Are you sure you want to remove all buy orders?"
@@ -2092,7 +2092,7 @@ msgstr "Farbschema"
 #: src/components/_military/mu/MuMemberList.tsx:327
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:155
 msgid "Commander"
-msgstr "Kommandant"
+msgstr "Kommandeur"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1853
 #: src/components/_user/notification/notification.frontConfig.tsx:1866
@@ -2695,15 +2695,15 @@ msgstr "Dein Konto löschen"
 
 #: src/components/_military/mu/MuMemberList.tsx:153
 msgid "Demote Commander"
-msgstr "Kommandanten degradieren"
+msgstr "Kommandeur degradieren"
 
 #: src/components/_military/mu/MuMemberList.tsx:440
 msgid "Demote from Commander"
-msgstr "Vom Kommandanten degradieren"
+msgstr "Vom Kommandeur degradieren"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1983
 msgid "Demoted from Commander"
-msgstr "Vom Kommandanten degradiert"
+msgstr "Vom Kommandeur degradiert"
 
 #: src/pages/region/[regionId]/index.tsx:60
 msgid "Deposit"
@@ -3370,7 +3370,7 @@ msgstr "Generiert <0>{0}</0>/Tag"
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:46
 msgid "Get an exclusive <0>subscriber skin</0>!"
-msgstr ""
+msgstr "Hol dir einen exklusiven <0>Abonnenten-Skin</0>!"
 
 #: src/components/_other/shop/SkinCollectionModal.tsx:94
 msgid "Get multiple skins at once with a 30% discount!"
@@ -3606,7 +3606,7 @@ msgstr "Hilf dem Spiel zu wachsen"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:157
 msgid "High Commander"
-msgstr "Hoher Kommandant"
+msgstr "Hoher Kommandeur"
 
 #: src/components/_military/battle/BattlesHeader.tsx:30
 msgid "History"
@@ -4258,7 +4258,7 @@ msgstr "Mitgliedsanträge"
 
 #: src/components/_military/mu/MuMemberList.tsx:116
 msgid "Member demoted from commander"
-msgstr "Mitglied vom Kommandanten degradiert"
+msgstr "Mitglied vom Kommandeur degradiert"
 
 #: src/components/_military/mu/MuMemberList.tsx:108
 msgid "Member kicked successfully"
@@ -4266,7 +4266,7 @@ msgstr "Mitglied erfolgreich entfernt"
 
 #: src/components/_military/mu/MuMemberList.tsx:112
 msgid "Member promoted to commander"
-msgstr "Mitglied zum Kommandanten befördert"
+msgstr "Mitglied zum Kommandeur befördert"
 
 #: src/components/_military/mercenaryContract/MercenaryContractModal.tsx:150
 #: src/pages/party/[partyId]/index.tsx:75
@@ -4952,7 +4952,7 @@ msgstr "Nur Buffs und Nahrungsvorkommen erscheinen in deinen Grenzen (Koka, Getr
 
 #: src/components/_military/tournament/TournamentRegisterButton.tsx:156
 msgid "Only MU owners/commanders can register their MU"
-msgstr "Nur MU-Besitzer/Kommandanten können ihre MU registrieren"
+msgstr "Nur MU-Besitzer/Kommandeure können ihre MU registrieren"
 
 #: src/components/_military/tournament/TournamentRegisterButton.tsx:148
 msgid "Only presidents can register their country"
@@ -5426,11 +5426,11 @@ msgstr "Profil"
 #: src/components/_military/mu/MuMemberList.tsx:146
 #: src/components/_military/mu/MuMemberList.tsx:434
 msgid "Promote to Commander"
-msgstr "Zum Kommandanten befördern"
+msgstr "Zum Kommandeur befördern"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1980
 msgid "Promoted to Commander"
-msgstr "Zum Kommandanten befördert"
+msgstr "Zum Kommandeur befördert"
 
 #: src/components/_military/battle/BattleSideContractsModal.tsx:45
 #: src/pages/battle/[battleId]/contracts.tsx:36
@@ -6337,7 +6337,7 @@ msgstr "Skin-Pakete"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2033
 msgid "Skin Reward"
-msgstr ""
+msgstr "Skin-Belohnung"
 
 #: src/components/_other/shop/ShopHeader.tsx:22
 #: src/pages/user/[userId]/index.tsx:93
@@ -7722,7 +7722,7 @@ msgstr "Du hast eine Kiste!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1110
 msgid "You have been demoted from commander in <0/> by <1/>"
-msgstr "Du wurdest von <1/> als Kommandant in <0/> abgesetzt."
+msgstr "Du wurdest von <1/> als Kommandeur in <0/> abgesetzt."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:320
 msgid "You have been elected as the new leader of <0/>"
@@ -7730,7 +7730,7 @@ msgstr "Du wurdest zum neuen Anführer von <0/> gewählt."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1096
 msgid "You have been promoted to commander in <0/> by <1/>"
-msgstr "Du wurdest von <1/> zum Kommandanten in <0/> befördert."
+msgstr "Du wurdest von <1/> zum Kommandeur in <0/> befördert."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1082
 msgid "You have been removed from <0/> by <1/>"
@@ -7829,7 +7829,7 @@ msgstr "Du hast eine Belohnung für {0} {1} im <0/>-Tier der Rangliste <1/> erha
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1801
 msgid "You received the skin \"{skinTitle}\"!"
-msgstr ""
+msgstr "Du hast den Skin \"{skinTitle}\" erhalten!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:592
 msgid "You sold items."


### PR DESCRIPTION
## Summary
- Change the German translation of commander-related strings from \"Kommandant\" to \"Kommandeur\", which fits the military context more naturally.
- Add three missing German translations for subscriber skin and skin reward notifications.