### PR TITLE
fr: complete missing translations (28 strings)

### DIFF
--- a/fr/messages.po
+++ b/fr/messages.po
@@ -73,7 +73,7 @@ msgstr "{0} vous a surpassé à ${1}/K"
 #. placeholder {0}: data.userId && ( <UserUsername userId={data.userId} withAvatar withFlag /> )
 #: src/components/_user/notification/notification.frontConfig.tsx:508
 msgid "{0} proposed a new law <0/>"
-msgstr ""
+msgstr "{0} a proposé une nouvelle loi <0/>"
 
 #. placeholder {0}: staticGameConfig.battle.roundsToWin
 #: src/components/_military/battle/RoundScore.tsx:55
@@ -165,7 +165,7 @@ msgstr "<0/> à <1>{0}</1> de salaire.{1}"
 #. placeholder {0}: law.data.amount ?? 0
 #: src/components/_political/law/law.frontConfig.tsx:380
 msgid "<0/> buys <1/> for <2>{0}</2>"
-msgstr ""
+msgstr "<0/> achète <1/> pour <2>{0}</2>"
 
 #. placeholder {0}: law.data.amount ?? 0
 #: src/components/_political/law/law.frontConfig.tsx:391
@@ -208,11 +208,11 @@ msgstr "<0/> a donné <1>{0}</1> à <2/>"
 #. placeholder {0}: ts[data.caseCode]
 #: src/components/_political/message/systemMessage.frontConfig.tsx:112
 msgid "<0/> dropped <1/> from <2>{0}</2>"
-msgstr ""
+msgstr "<0/> a retiré <1/> de <2>{0}</2>"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:150
 msgid "<0/> ended <1/>"
-msgstr ""
+msgstr "<0/> a terminé <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:142
 msgid "<0/> financed a resistance war for <1/> in <2/>"
@@ -386,7 +386,7 @@ msgstr "La priorité de <0/> se termine dans <1/>"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:124
 msgid "<0/> proposed a new law: <1/>"
-msgstr ""
+msgstr "<0/> a proposé une nouvelle loi : <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:740
 msgid "<0/> published a new article"
@@ -408,7 +408,7 @@ msgstr "<0/> a répondu à ton message {0}"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:141
 msgid "<0/> started, vote for your favorite candidate"
-msgstr ""
+msgstr "<0/> a commencé, votez pour votre candidat préféré"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:805
 msgid "<0/> subscribed to you on your article <1/>"
@@ -428,7 +428,7 @@ msgstr "Guerre <0/> vs <1/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:91
 msgid "<0/> wants peace"
-msgstr ""
+msgstr "<0/> veut la paix"
 
 #: src/components/_political/law/law.frontConfig.tsx:101
 msgid "<0/> wants to make peace with your country"
@@ -1133,7 +1133,7 @@ msgstr "Accepter l'alliance"
 
 #: src/components/_political/law/law.frontConfig.tsx:289
 msgid "Accept alliance with <0/>"
-msgstr ""
+msgstr "Accepter l'alliance avec <0/>"
 
 #. placeholder {0}: gameConfig?.battle.allianceDamagesBonusPercent
 #: src/components/_political/law/law.frontConfig.tsx:300
@@ -1468,7 +1468,7 @@ msgstr "Êtes-vous sûr de vouloir quitter le gouvernement ?"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:131
 msgid "Are you sure you want to place this bid?"
-msgstr ""
+msgstr "Êtes-vous sûr de vouloir placer cette offre ?"
 
 #: src/components/_military/mu/MuMemberList.tsx:147
 msgid "Are you sure you want to promote this member to commander?"
@@ -1762,7 +1762,7 @@ msgstr "Bottes"
 
 #: src/components/_military/battle/LootSummaryCard.tsx:104
 msgid "Bounty"
-msgstr ""
+msgstr "Prime"
 
 #: src/components/_military/battle/BattleSystem.tsx:844
 #: src/components/_military/battle/BattleSystem.tsx:854
@@ -1784,7 +1784,7 @@ msgstr "Rompre l'alliance"
 
 #: src/components/_political/law/law.frontConfig.tsx:320
 msgid "Break alliance with <0/>"
-msgstr ""
+msgstr "Rompre l'alliance avec <0/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:316
 msgid "Break an alliance with another country"
@@ -1849,7 +1849,7 @@ msgstr "Bunker"
 #. placeholder {0}: law.data.amount ?? 0
 #: src/components/_political/law/law.frontConfig.tsx:408
 msgid "Buy <0/> from <1/> for <2>{0}</2>"
-msgstr ""
+msgstr "Acheter <0/> à <1/> pour <2>{0}</2>"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:168
 msgid "Buy for <0>{count}</0> money on market"
@@ -1923,7 +1923,7 @@ msgstr "Annulé par un administrateur"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:133
 msgid "Candidacy is open for <0/>"
-msgstr ""
+msgstr "Les candidatures sont ouvertes pour <0/>"
 
 #: src/components/_political/election/CandidateFormModal.tsx:86
 msgid "Candidate"
@@ -1992,7 +1992,7 @@ msgstr "Chance de toucher la cible.<0/>Les ratés ne peuvent pas être critiques
 #. placeholder {0}: law.data.taxType
 #: src/components/_political/law/law.frontConfig.tsx:62
 msgid "Change {0} tax to <0/>"
-msgstr ""
+msgstr "Modifier la taxe {0} à <0/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:58
 msgid "Change a country tax"
@@ -2736,7 +2736,7 @@ msgstr "Définir <0/> comme ennemi principal, augmentant les dégâts lorsque vo
 
 #: src/components/_political/law/law.frontConfig.tsx:215
 msgid "Define <0/> as enemy"
-msgstr ""
+msgstr "Définir <0/> comme ennemi"
 
 #: src/components/_political/law/law.frontConfig.tsx:211
 msgid "Define a country as an enemy to get bonus against"
@@ -3164,15 +3164,15 @@ msgstr "Expiré"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:66
 msgid "Expired: battle ended"
-msgstr ""
+msgstr "Expiré : bataille terminée"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:64
 msgid "Expired: no bids"
-msgstr ""
+msgstr "Expiré : aucune offre"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:68
 msgid "Expired: round ended"
-msgstr ""
+msgstr "Expiré : manche terminée"
 
 #: src/pages/region/[regionId]/index.tsx:79
 msgid "Expires in"
@@ -3348,7 +3348,7 @@ msgstr "Financer la résistance locale"
 
 #: src/components/_political/law/law.frontConfig.tsx:555
 msgid "Finance resistance in <0/>"
-msgstr ""
+msgstr "Financer la résistance dans <0/>"
 
 #: src/pages/companies.tsx:59
 #: src/pages/user/[userId]/companies.tsx:73
@@ -3654,7 +3654,7 @@ msgstr "Pistolet"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:236
 msgid "Hamster Tank"
-msgstr ""
+msgstr "Tank Hamster"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:85
 msgid "Hard Worker"
@@ -3760,7 +3760,7 @@ msgstr "Imagine gaspiller ton clic pour ça"
 
 #: src/components/_political/law/law.frontConfig.tsx:187
 msgid "Impeach <0/>"
-msgstr ""
+msgstr "Destituer <0/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:181
 #: src/components/_political/law/lawNames.tsx:22
@@ -4111,7 +4111,7 @@ msgstr "Niveau supérieur !"
 
 #: src/components/_political/law/law.frontConfig.tsx:435
 msgid "Liberate <0/>"
-msgstr ""
+msgstr "Libérer <0/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:444
 msgid "Liberate <0/> and return it to its original country"
@@ -4406,7 +4406,7 @@ msgstr "Les contrats de mercenaires sont actuellement désactivés."
 
 #: src/components/_military/battle/LootSummaryCard.tsx:90
 msgid "Mercenary earnings"
-msgstr ""
+msgstr "Gains mercenaires"
 
 #: src/components/_military/mercenaryContract/MercenaryReputationTooltip.tsx:15
 msgid "Mercenary Reputation"
@@ -4736,7 +4736,7 @@ msgstr "Nouvel emplacement"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionList.tsx:121
 msgid "New Mercenary Auction"
-msgstr ""
+msgstr "Nouvelle enchère mercenaire"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2029
 msgid "New message"
@@ -5554,7 +5554,7 @@ msgstr "Proposer une alliance"
 
 #: src/components/_political/law/law.frontConfig.tsx:260
 msgid "Propose alliance to <0/>"
-msgstr ""
+msgstr "Proposer une alliance à <0/>"
 
 #. placeholder {0}: gameConfig?.battle.allianceDamagesBonusPercent
 #: src/components/_political/law/law.frontConfig.tsx:269
@@ -6322,7 +6322,7 @@ msgstr "Définir la couleur du pays"
 #. placeholder {0}: law.data.scheme
 #: src/components/_political/law/law.frontConfig.tsx:473
 msgid "Set country color to <0>{0}</0> "
-msgstr ""
+msgstr "Définir la couleur du pays sur <0>{0}</0> "
 
 #: src/components/_political/partyMotion/partyMotion.frontConfig.tsx:88
 msgid "Set new party ethics configuration:"
@@ -6849,7 +6849,7 @@ msgstr "L'univers te doit quelque chose de gros"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:132
 msgid "This action will submit your MU bid for this contract."
-msgstr ""
+msgstr "Cette action soumettra l'offre de votre UM pour ce contrat."
 
 #: src/components/_military/battle/BattleSystem.tsx:793
 msgid "This bounty is reserved for nationals only."
@@ -7172,7 +7172,7 @@ msgstr "Transférer à l'entreprise (optionnel)"
 
 #: src/components/_political/law/law.frontConfig.tsx:344
 msgid "Transfer<0/> to <1/>"
-msgstr ""
+msgstr "Transférer <0/> à <1/>"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:209
 msgid "Translator"

--- a/it/messages.po
+++ b/it/messages.po
@@ -68,12 +68,12 @@ msgstr "{0} ore"
 #. placeholder {1}: data.newPerK
 #: src/components/_user/notification/notification.frontConfig.tsx:1622
 msgid "{0} outbid you at ${1}/K"
-msgstr ""
+msgstr "{0} ti ha superato a ${1}/K"
 
 #. placeholder {0}: data.userId && ( <UserUsername userId={data.userId} withAvatar withFlag /> )
 #: src/components/_user/notification/notification.frontConfig.tsx:508
 msgid "{0} proposed a new law <0/>"
-msgstr ""
+msgstr "{0} ha proposto una nuova legge <0/>"
 
 #. placeholder {0}: staticGameConfig.battle.roundsToWin
 #: src/components/_military/battle/RoundScore.tsx:55
@@ -108,15 +108,15 @@ msgstr "{0}% dell'investito"
 
 #: src/components/_military/battle/BattleName.tsx:141
 msgid "{battleIcon}Battle for {regionName} {score}"
-msgstr ""
+msgstr "{battleIcon}Battaglia per {regionName} {score}"
 
 #: src/components/_military/battle/BattleName.tsx:146
 msgid "{battleIcon}Resistance for {regionName} {score}"
-msgstr ""
+msgstr "{battleIcon}Resistenza per {regionName} {score}"
 
 #: src/components/_military/battle/BattleName.tsx:151
 msgid "{battleIcon}Revolution {score}"
-msgstr ""
+msgstr "{battleIcon}Rivoluzione {score}"
 
 #: src/components/_military/battle/BattleName.tsx:156
 msgid "{battleIcon}Tournament battle for {tournamentName} {score}"
@@ -132,7 +132,7 @@ msgstr "{registeredCount} {entityLabel} registrati"
 
 #: src/components/_military/battle/BattleTimeline.tsx:79
 msgid "{roundsToWin} Rounds to win "
-msgstr ""
+msgstr "{roundsToWin} round per vincere "
 
 #. placeholder {0}: staticGameConfig.battle.roundsToWin
 #: src/components/_military/battle/RoundScore.tsx:50
@@ -149,7 +149,7 @@ msgstr "*Può bruciare"
 
 #: src/components/_political/government/Government.tsx:197
 msgid "/day"
-msgstr ""
+msgstr "/giorno"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:378
 #: src/components/_user/notification/notification.frontConfig.tsx:1069
@@ -165,7 +165,7 @@ msgstr "<0/> con salario <1>{0}</1>.{1}"
 #. placeholder {0}: law.data.amount ?? 0
 #: src/components/_political/law/law.frontConfig.tsx:380
 msgid "<0/> buys <1/> for <2>{0}</2>"
-msgstr ""
+msgstr "<0/> acquista <1/> per <2>{0}</2>"
 
 #. placeholder {0}: law.data.amount ?? 0
 #: src/components/_political/law/law.frontConfig.tsx:391
@@ -174,7 +174,7 @@ msgstr "<0/> compra la tua regione <1/> per <2>{0}</2>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1542
 msgid "<0/> cancelled the contract."
-msgstr ""
+msgstr "<0/> ha annullato il contratto."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:771
 msgid "<0/> commented on your article <1/>"
@@ -182,7 +182,7 @@ msgstr "<0/> ha commentato il tuo articolo <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1517
 msgid "<0/> completed a contract, you earned <1/>"
-msgstr ""
+msgstr "<0/> ha completato un contratto, hai guadagnato <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:664
 msgid "<0/> conquered the region in <1/>"
@@ -194,7 +194,7 @@ msgstr "<0/> ha creato la conversazione"
 
 #: src/components/_political/event/event.frontConfig.tsx:174
 msgid "<0/> declared war on <1/>"
-msgstr ""
+msgstr "<0/> ha dichiarato guerra a <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:659
 msgid "<0/> defended in <1/>"
@@ -208,23 +208,23 @@ msgstr "<0/> ha donato <1>{0}</1> a <2/>"
 #. placeholder {0}: ts[data.caseCode]
 #: src/components/_political/message/systemMessage.frontConfig.tsx:112
 msgid "<0/> dropped <1/> from <2>{0}</2>"
-msgstr ""
+msgstr "<0/> ha rimosso <1/> da <2>{0}</2>"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:150
 msgid "<0/> ended <1/>"
-msgstr ""
+msgstr "<0/> ha terminato <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:142
 msgid "<0/> financed a resistance war for <1/> in <2/>"
-msgstr ""
+msgstr "<0/> ha finanziato una guerra di resistenza per <1/> in <2/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:149
 msgid "<0/> financed a revolt in <1/>"
-msgstr ""
+msgstr "<0/> ha finanziato una rivolta in <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:445
 msgid "<0/> financed a revolt in <1/> for <2/> against <3/>"
-msgstr ""
+msgstr "<0/> ha finanziato una rivolta in <1/> per <2/> contro <3/>"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:53
 msgid "<0/> gifted a sub to <1/>"
@@ -250,7 +250,7 @@ msgstr "<0/> ti ha regalato il pacchetto di skin \"{0}\"!"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:227
 msgid "<0/> got fee back"
-msgstr ""
+msgstr "<0/> ha ricevuto il rimborso della commissione"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1297
 msgid "<0/> has been created, it gonna start soon!"
@@ -263,35 +263,35 @@ msgstr "<0/> è stato eletto presidente di <1/>"
 #. placeholder {0}: data.amount
 #: src/components/_political/event/event.frontConfig.tsx:210
 msgid "<0/> has bought <1/> from <2/> for <3>{0}</3>"
-msgstr ""
+msgstr "<0/> ha acquistato <1/> da <2/> per <3>{0}</3>"
 
 #: src/components/_political/event/event.frontConfig.tsx:326
 msgid "<0/> has broken their alliance with <1/>"
-msgstr ""
+msgstr "<0/> ha rotto l'alleanza con <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:97
 msgid "<0/> has conquered <1/> against <2/>"
-msgstr ""
+msgstr "<0/> ha conquistato <1/> contro <2/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:116
 msgid "<0/> has defended <1/> against <2/>"
-msgstr ""
+msgstr "<0/> ha difeso <1/> contro <2/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:452
 msgid "<0/> has financed a revolt in <1/> for <2/> against <3/>"
-msgstr ""
+msgstr "<0/> ha finanziato una rivolta in <1/> per <2/> contro <3/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:369
 msgid "<0/> has financed resistance in <1/>"
-msgstr ""
+msgstr "<0/> ha finanziato la resistenza in <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:311
 msgid "<0/> has formed an alliance with <1/>"
-msgstr ""
+msgstr "<0/> ha formato un'alleanza con <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:226
 msgid "<0/> has liberated <1/> and returned it to <2/>"
-msgstr ""
+msgstr "<0/> ha liberato <1/> e l'ha restituita a <2/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:932
 msgid "<0/> has started a revolution in <1/>"
@@ -303,12 +303,12 @@ msgstr "<0/> è iniziato! Che le battaglie abbiano inizio!"
 
 #: src/components/_political/event/event.frontConfig.tsx:383
 msgid "<0/> has suppressed resistance in <1/>"
-msgstr ""
+msgstr "<0/> ha soppresso la resistenza in <1/>"
 
 #. placeholder {0}: data.money
 #: src/components/_political/event/event.frontConfig.tsx:253
 msgid "<0/> has transferred <1>{0}</1> to <2/>"
-msgstr ""
+msgstr "<0/> ha trasferito <1>{0}</1> a <2/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:888
 msgid "<0/> is attacking <1/> in <2/>"
@@ -316,7 +316,7 @@ msgstr "<0/> sta attaccando <1/> in <2/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:160
 msgid "<0/> is attacking in <1/>"
-msgstr ""
+msgstr "<0/> sta attaccando in <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:874
 msgid "<0/> is attacking your country in <1/>"
@@ -324,11 +324,11 @@ msgstr "<0/> sta attaccando il tuo paese in <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:298
 msgid "<0/> is in bankruptcy. Removing all alliances and disabling every region upgrades."
-msgstr ""
+msgstr "<0/> è in bancarotta. Tutte le alleanze vengono rimosse e i miglioramenti delle regioni disabilitati."
 
 #: src/components/_political/event/event.frontConfig.tsx:155
 msgid "<0/> is revolting in <1/>"
-msgstr ""
+msgstr "<0/> sta rivoltando in <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:903
 msgid "<0/> is revolting in <1/> against your country"
@@ -370,7 +370,7 @@ msgstr "<0/> ha messo mi piace al tuo messaggio <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:241
 msgid "<0/> made peace with <1/>"
-msgstr ""
+msgstr "<0/> ha fatto pace con <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1185
 msgid "<0/> mentioned you in a message <1/>"
@@ -378,7 +378,7 @@ msgstr "<0/> ti ha menzionato in un messaggio <1/>"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:221
 msgid "<0/> paid fee"
-msgstr ""
+msgstr "<0/> ha pagato la commissione"
 
 #: src/components/_military/war/WarItem.tsx:115
 msgid "<0/> Priority ends in <1/>"
@@ -386,7 +386,7 @@ msgstr "<0/> La priorità termina tra <1/>"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:124
 msgid "<0/> proposed a new law: <1/>"
-msgstr ""
+msgstr "<0/> ha proposto una nuova legge: <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:740
 msgid "<0/> published a new article"
@@ -395,7 +395,7 @@ msgstr "<0/> ha pubblicato un nuovo articolo"
 #. placeholder {0}: data.level
 #: src/components/_user/notification/notification.frontConfig.tsx:1170
 msgid "<0/> reached level {0}!"
-msgstr ""
+msgstr "<0/> ha raggiunto il livello {0}!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:558
 msgid "<0/> referred you to the game."
@@ -408,7 +408,7 @@ msgstr "<0/> ha risposto al tuo messaggio {0}"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:141
 msgid "<0/> started, vote for your favorite candidate"
-msgstr ""
+msgstr "<0/> è iniziato, vota il tuo candidato preferito"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:805
 msgid "<0/> subscribed to you on your article <1/>"
@@ -420,7 +420,7 @@ msgstr "<0/> ha lasciato una mancia al tuo articolo <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:196
 msgid "<0/> took control of <1/>"
-msgstr ""
+msgstr "<0/> ha preso il controllo di <1/>"
 
 #: src/components/_military/war/WarHeader.tsx:28
 msgid "<0/> vs <1/> war"
@@ -428,7 +428,7 @@ msgstr "Guerra <0/> vs <1/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:91
 msgid "<0/> wants peace"
-msgstr ""
+msgstr "<0/> vuole la pace"
 
 #: src/components/_political/law/law.frontConfig.tsx:101
 msgid "<0/> wants to make peace with your country"
@@ -436,7 +436,7 @@ msgstr "<0/> vuole fare pace con il tuo paese"
 
 #: src/components/_political/event/event.frontConfig.tsx:191
 msgid "<0/> was elected president of <1/>"
-msgstr ""
+msgstr "<0/> è stato eletto presidente di <1/>"
 
 #. placeholder {0}: ts[data.governmentRole]
 #: src/components/_user/notification/notification.frontConfig.tsx:524
@@ -450,7 +450,7 @@ msgstr "<0/> ha vinto il round {0}"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1500
 msgid "<0/> won the auction on a contract with <1/>"
-msgstr ""
+msgstr "<0/> ha vinto l'asta per un contratto con <1/>"
 
 #. placeholder {0}: data.attackerWonRoundsCount
 #. placeholder {1}: data.defenderWonRoundsCount
@@ -491,7 +491,7 @@ msgstr "<0/>La priorità termina tra <1/>"
 #. placeholder {0}: levelConfig.stats.resistanceGrowthReduction ?? 0
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:58
 msgid "<0>-{0}%</0> Resistance growth per hour"
-msgstr ""
+msgstr "<0>-{0}%</0> crescita della resistenza per ora"
 
 #. placeholder {0}: companiesIds?.length ?? 0
 #. placeholder {1}: companiesLimit ?? 99
@@ -524,7 +524,7 @@ msgstr "<0>{0}</0> contro il nemico di <1/>"
 #. placeholder {0}: levelConfig.stats.attackBonus || 0
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:46
 msgid "<0>{0}</0> Attack bonus"
-msgstr ""
+msgstr "<0>{0}</0> bonus attacco"
 
 #. placeholder {0}: sideBonus.regionNotLinkedToCapitalMalusPercent
 #: src/components/_military/battle/BattleDamageBonuses.tsx:163
@@ -544,12 +544,12 @@ msgstr "<0>{0}</0> perché <1/> occupa almeno una delle regioni di <2/>"
 #. placeholder {0}: levelConfig.stats.defenseBonus || 0
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:34
 msgid "<0>{0}</0> Defense bonus"
-msgstr ""
+msgstr "<0>{0}</0> bonus difesa"
 
 #. placeholder {0}: data.acceptanceFeeReturned
 #: src/components/_user/notification/notification.frontConfig.tsx:1563
 msgid "<0>{0}</0> fee returned to MU."
-msgstr ""
+msgstr "Commissione <0>{0}</0> restituita all'UM."
 
 #. placeholder {0}: sideBonus.regionAttackBonusPercent
 #. placeholder {0}: sideBonus.regionDefenseBonusPercent
@@ -626,12 +626,12 @@ msgstr "Servono <0>{0}</0> punti terreno per vincere un round, i punti si otteng
 #. placeholder {0}: data.refund
 #: src/components/_user/notification/notification.frontConfig.tsx:1555
 msgid "<0>{0}</0> returned to <1/>."
-msgstr ""
+msgstr "<0>{0}</0> restituito a <1/>."
 
 #. placeholder {0}: levelConfig.stats.maxProduction
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:81
 msgid "<0>{0}</0> Storage capacity"
-msgstr ""
+msgstr "<0>{0}</0> capacità di stoccaggio"
 
 #. placeholder {0}: -lawConfig.maintenanceCost
 #: src/components/_political/law/Law.tsx:99
@@ -674,12 +674,12 @@ msgstr "<0>Emote</0> in chat"
 #. placeholder {0}: ts.case2
 #: src/components/_military/damageRanking/BattleLoot.tsx:62
 msgid "<0>Every <1/> damage dealt in this round across both sides rolls an <2>{0}</2> into the round loot pool.</0><3>Round loot are distributed at the end of the round, top 1 damage dealer get top 1 item and so on...</3>"
-msgstr ""
+msgstr "<0>Ogni <1/> danno inflitto in questo round da entrambe le parti aggiunge un <2>{0}</2> al pool bottino del round.</0><3>Il bottino del round viene distribuito alla fine del round, chi ha inflitto più danni ottiene l'oggetto migliore e così via...</3>"
 
 #. placeholder {0}: ts.case2
 #: src/components/_military/damageRanking/BattleLoot.tsx:75
 msgid "<0>Every <1/> total damage dealt across both sides rolls an <2>{0}</2> into the battle loot pool.</0><3>Battle loot are distributed at the end of the battle, top 1 damage dealer get top 1 item and so on...</3>"
-msgstr ""
+msgstr "<0>Ogni <1/> danno totale inflitto da entrambe le parti aggiunge un <2>{0}</2> al pool bottino della battaglia.</0><3>Il bottino della battaglia viene distribuito alla fine della battaglia, chi ha inflitto più danni ottiene l'oggetto migliore e così via...</3>"
 
 #. placeholder {0}: 1
 #. placeholder {1}: worker.fidelity
@@ -700,11 +700,11 @@ msgstr "<0>Riempito con <1>Punti Produzione</1> dai dipendenti che lavorano e da
 #. placeholder {5}: gameConfig?.unrest.contributionCooldownAfterRevolutionHours
 #: src/components/_political/unrest/UnrestBar.tsx:25
 msgid "<0>Unrest</0> represents internal tension in the country.<1/><2/>Citizens can <3>increase</3> or <4>decrease</4> unrest by spending <5>{0}</5> or <6>{1}</6> to change the bar by <7>{2}</7>.<8/><9/>When the bar is full, any party can vote via motion to start a <10>Civil war</10> (cost: <11>development × 10</11>, cooldown: {3}h). The battle takes place in the capital region, and <12>only citizens</12> can fight.<13/><14/>If revolutionaries win:<15/>- Government is impeached<16/>- Borders are opened for {4} days<17/>- Presidential elections begin<18/><19/>After a revolution, contributions are disabled for {5}h."
-msgstr ""
+msgstr "<0>Il <0>Malcontento</0> rappresenta la tensione interna nel paese.<1/><2/>I cittadini possono <3>aumentare</3> o <4>diminuire</4> il malcontento spendendo <5>{0}</5> o <6>{1}</6> per cambiare la barra di <7>{2}</7>.<8/><9/>Quando la barra è piena, qualsiasi partito può votare tramite mozione per avviare una <10>Guerra civile</10> (costo: <11>sviluppo × 10</11>, cooldown: {3}h). La battaglia si svolge nella regione capitale e <12>solo i cittadini</12> possono combattere.<13/><14/>Se i rivoluzionari vincono:<15/>- Il governo viene destituito<16/>- I confini vengono aperti per {4} giorni<17/>- Iniziano le elezioni presidenziali<18/><19/>Dopo una rivoluzione, i contributi sono disabilitati per {5}h."
 
 #: src/components/_user/modals/PhoneVerificationModal.tsx:108
 msgid "<0>Your account requires additional verification. Please verify your phone number as soon as possible to continue using your account normally. Unverified accounts will have restricted access after 48 hours and may be permanently suspended after 5 days.</0><1>Phone numbers are encrypted and not visible to any administrator.</1>"
-msgstr ""
+msgstr "<0>Il tuo account richiede una verifica aggiuntiva. Verifica il tuo numero di telefono il prima possibile per continuare a utilizzare il tuo account normalmente. Gli account non verificati avranno accesso limitato dopo 48 ore e potrebbero essere sospesi definitivamente dopo 5 giorni.</0><1>I numeri di telefono sono crittografati e non visibili ad alcun amministratore.</1>"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:86
 msgid "1 legendary down, 5 more to go for a full stuff, keep gambling!"
@@ -1072,7 +1072,7 @@ msgstr "Un bellissimo nome utente colorato che ti renderà molto popolare"
 
 #: src/components/_political/event/event.frontConfig.tsx:398
 msgid "A civil war has started by <0/> in <1/>"
-msgstr ""
+msgstr "Una guerra civile è iniziata da <0/> in <1/>"
 
 #: src/pages/region/[regionId]/index.tsx:57
 msgid "A deposit has been found in this region, it can be exploited by companies to produce raws."
@@ -1083,21 +1083,21 @@ msgstr "In questa regione è stato trovato un giacimento: può essere sfruttato 
 #. placeholder {2}: data.durationDays
 #: src/components/_political/event/event.frontConfig.tsx:266
 msgid "A deposit of <0>{0}</0> <1>{1}</1> has been found in <2/> for {2} days"
-msgstr ""
+msgstr "Un giacimento di <0>{0}</0> <1>{1}</1> è stato trovato in <2/> per {2} giorni"
 
 #. placeholder {0}: contract.acceptanceFee
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:97
 msgid "A fee of <0>{0}</0> is required to accept this contract. The fee is returned once you complete the minimum damage of <1/>. If you fail to complete the contract or the country cancels it, the fee is lost."
-msgstr ""
+msgstr "È richiesta una commissione di <0>{0}</0> per accettare questo contratto. La commissione viene restituita una volta completato il danno minimo di <1/>. Se non riesci a completare il contratto o il paese lo annulla, la commissione viene persa."
 
 #. placeholder {0}: contract.acceptanceFee
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:91
 msgid "A fee of <0>{0}</0> was required to accept this contract. The fee has been returned after completing the minimum damage."
-msgstr ""
+msgstr "Era richiesta una commissione di <0>{0}</0> per accettare questo contratto. La commissione è stata restituita dopo aver completato il danno minimo."
 
 #: src/components/_political/event/event.frontConfig.tsx:137
 msgid "A revolution has started in <0/>"
-msgstr ""
+msgstr "Una rivoluzione è iniziata in <0/>"
 
 #: src/pages/region/[regionId]/index.tsx:94
 msgid "A strategic resource has been found in this region, it gives its owner a production and development bonus."
@@ -1105,7 +1105,7 @@ msgstr "In questa regione è stata trovata una risorsa strategica: garantisce al
 
 #: src/components/_user/modals/PhoneVerificationModal.tsx:144
 msgid "A verification code has been sent to {phoneNumber}"
-msgstr ""
+msgstr "Un codice di verifica è stato inviato a {phoneNumber}"
 
 #: src/components/_political/law/Law.tsx:170
 #: src/components/_political/partyMotion/PartyMotion.tsx:169
@@ -1114,7 +1114,7 @@ msgstr "Astieniti"
 
 #: src/components/_user/userReports/ReportFormModal.tsx:84
 msgid "Abusing or spamming the report system may lead to sanctions."
-msgstr ""
+msgstr "L'abuso o lo spam del sistema di segnalazione può portare a sanzioni."
 
 #: src/pages/country/[countryId]/index.tsx:132
 msgid "Abusing this power to advantage another country will lead to a <0>ban.</0>"
@@ -1133,7 +1133,7 @@ msgstr "Accetta alleanza"
 
 #: src/components/_political/law/law.frontConfig.tsx:289
 msgid "Accept alliance with <0/>"
-msgstr ""
+msgstr "Accetta alleanza con <0/>"
 
 #. placeholder {0}: gameConfig?.battle.allianceDamagesBonusPercent
 #: src/components/_political/law/law.frontConfig.tsx:300
@@ -1209,7 +1209,7 @@ msgstr "Guerre attive"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:179
 msgid "Activity"
-msgstr ""
+msgstr "Attività"
 
 #: src/components/_user/user/FamilyGroup.tsx:70
 msgid "Add User"
@@ -1294,7 +1294,7 @@ msgstr "Tutti i tipi di evento"
 
 #: src/components/_user/notification/NotificationPrefsPanel.tsx:188
 msgid "All Ingame"
-msgstr ""
+msgstr "Tutti in gioco"
 
 #: src/components/_social/ArticleList.tsx:120
 msgid "All languages"
@@ -1307,7 +1307,7 @@ msgstr "Tutti i costi di attuazione delle leggi sono moltiplicati per {0}."
 
 #: src/components/_user/notification/NotificationPrefsPanel.tsx:168
 msgid "All Mobile"
-msgstr ""
+msgstr "Tutti mobile"
 
 #: src/pages/party/[partyId]/index.tsx:112
 msgid "All Parties"
@@ -1315,7 +1315,7 @@ msgstr "Tutti i partiti"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:204
 msgid "All rounds"
-msgstr ""
+msgstr "Tutti i round"
 
 #: src/components/_other/shop/SkinPackModal.tsx:285
 msgid "All skins owned"
@@ -1356,7 +1356,7 @@ msgstr "Quasi pronto..."
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:115
 msgid "Alpha Tester"
-msgstr ""
+msgstr "Alpha Tester"
 
 #: src/components/_user/UserEquipments.tsx:128
 #: src/utils/translations.tsx:35
@@ -1365,7 +1365,7 @@ msgstr "Munizioni"
 
 #: src/components/_user/user/SkillValue.tsx:136
 msgid "Ammo:"
-msgstr ""
+msgstr "Munizioni:"
 
 #: src/components/_political/law/LawFormModal.tsx:250
 #: src/components/_political/law/LawFormModal.tsx:251
@@ -1387,15 +1387,15 @@ msgstr "Numero di aziende che puoi possedere"
 #. placeholder {0}: data.refund
 #: src/components/_user/notification/notification.frontConfig.tsx:1535
 msgid "An admin cancelled the contract. <0>{0}</0> returned to <1/>."
-msgstr ""
+msgstr "Un amministratore ha annullato il contratto. <0>{0}</0> restituito a <1/>."
 
 #: src/components/_political/event/event.frontConfig.tsx:331
 msgid "An alliance has been broken"
-msgstr ""
+msgstr "Un'alleanza è stata rotta"
 
 #: src/components/_political/event/event.frontConfig.tsx:316
 msgid "An alliance has been formed"
-msgstr ""
+msgstr "Un'alleanza è stata formata"
 
 #: src/components/_user/auth/LoginFormModal.tsx:94
 msgid "An email with the verification code has been sent to {email}"
@@ -1440,15 +1440,15 @@ msgstr "Fai richiesta"
 
 #: src/utils/translations.tsx:261
 msgid "Approved"
-msgstr ""
+msgstr "Approvato"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:179
 msgid "Arcane Boots"
-msgstr ""
+msgstr "Stivali Arcani"
 
 #: src/components/_military/mu/MuMemberList.tsx:154
 msgid "Are you sure you want to demote this commander?"
-msgstr ""
+msgstr "Sei sicuro di voler retrocedere questo comandante?"
 
 #: src/components/_user/worker/WorkerEditFormModal.tsx:113
 msgid "Are you sure you want to fire this worker?"
@@ -1456,7 +1456,7 @@ msgstr "Sei sicuro di voler licenziare questo lavoratore?"
 
 #: src/components/_military/mu/MuMemberList.tsx:140
 msgid "Are you sure you want to kick this member?"
-msgstr ""
+msgstr "Sei sicuro di voler espellere questo membro?"
 
 #: src/pages/country/[countryId]/government.tsx:93
 msgid "Are you sure you want to leave the congress?"
@@ -1468,11 +1468,11 @@ msgstr "Sei sicuro di voler lasciare il governo?"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:131
 msgid "Are you sure you want to place this bid?"
-msgstr ""
+msgstr "Sei sicuro di voler fare questa offerta?"
 
 #: src/components/_military/mu/MuMemberList.tsx:147
 msgid "Are you sure you want to promote this member to commander?"
-msgstr ""
+msgstr "Sei sicuro di voler promuovere questo membro a comandante?"
 
 #: src/pages/market/index.tsx:170
 msgid "Are you sure you want to remove all buy orders?"
@@ -1497,7 +1497,7 @@ msgstr "Sei sicuro di voler saltare questo tutorial?"
 
 #: src/components/_military/mu/MuMemberList.tsx:162
 msgid "Are you sure you want to transfer ownership to this member? This action cannot be undone."
-msgstr ""
+msgstr "Sei sicuro di voler trasferire la proprietà a questo membro? Questa azione non può essere annullata."
 
 #: src/components/_user/user/skills.frontConfig.tsx:71
 #: src/components/_user/user/skills.frontConfig.tsx:72
@@ -1555,25 +1555,25 @@ msgstr "Attaccanti"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:177
 msgid "Auction Duration (minutes)"
-msgstr ""
+msgstr "Durata asta (minuti)"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2022
 msgid "Auction Outbid"
-msgstr ""
+msgstr "Offerta superata"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:218
 msgid "Auction Won"
-msgstr ""
+msgstr "Asta vinta"
 
 #: src/components/_military/battle/BattleHeader.tsx:305
 #: src/components/_military/battle/BattlesHeader.tsx:37
 #: src/components/_military/battle/BattleSideContractsModal.tsx:37
 msgid "Auctions"
-msgstr ""
+msgstr "Aste"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:141
 msgid "Authentication failed. Please try again."
-msgstr ""
+msgstr "Autenticazione fallita. Riprova."
 
 #: src/pages/country/[countryId]/citizenship.tsx:47
 msgid "Auto approval"
@@ -1598,7 +1598,7 @@ msgstr "Avatar rimosso"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:170
 msgid "Baby Boomer"
-msgstr ""
+msgstr "Baby Boomer"
 
 #: src/components/_user/referral/ReferralList.tsx:110
 msgid "Badge won"
@@ -1683,15 +1683,15 @@ msgstr "Battaglia terminata"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:73
 msgid "Battle Hero"
-msgstr ""
+msgstr "Eroe della battaglia"
 
 #: src/components/_military/damageRanking/BattleLoot.tsx:60
 msgid "Battle loot"
-msgstr ""
+msgstr "Bottino di battaglia"
 
 #: src/components/_military/damageRanking/BattleLoot.tsx:90
 msgid "Battle loot pool"
-msgstr ""
+msgstr "Pool bottino di battaglia"
 
 #: src/components/_political/event/EventList.tsx:64
 msgid "Battle opened"
@@ -1699,7 +1699,7 @@ msgstr "Battaglia aperta"
 
 #: src/components/_military/battle/BattleSideOrdersModal.tsx:99
 msgid "Battle Orders"
-msgstr ""
+msgstr "Ordini di battaglia"
 
 #: src/components/_layout/LayoutMenu.tsx:154
 #: src/components/_military/battle/BattlesHeader.tsx:21
@@ -1736,7 +1736,7 @@ msgstr "Meglio di niente, no?"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:289
 msgid "Bid"
-msgstr ""
+msgstr "Offerta"
 
 #: src/components/_user/user/UserDropdown.tsx:278
 msgid "Block (hide content)"
@@ -1744,7 +1744,7 @@ msgstr "Blocca (nascondi contenuti)"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:161
 msgid "Blue Staff"
-msgstr ""
+msgstr "Bastone Blu"
 
 #: src/components/_military/battle/BattleDamageBonuses.tsx:47
 #: src/components/_political/law/law.frontConfig.tsx:241
@@ -1762,16 +1762,16 @@ msgstr "Stivali"
 
 #: src/components/_military/battle/LootSummaryCard.tsx:104
 msgid "Bounty"
-msgstr ""
+msgstr "Taglia"
 
 #: src/components/_military/battle/BattleSystem.tsx:844
 #: src/components/_military/battle/BattleSystem.tsx:854
 msgid "Bounty cooldown"
-msgstr ""
+msgstr "Cooldown taglia"
 
 #: src/components/_military/battle/BattleSystem.tsx:830
 msgid "Bounty will be available in"
-msgstr ""
+msgstr "La taglia sarà disponibile tra"
 
 #: src/utils/translations.tsx:31
 msgid "Bread"
@@ -1784,7 +1784,7 @@ msgstr "Sciogli alleanza"
 
 #: src/components/_political/law/law.frontConfig.tsx:320
 msgid "Break alliance with <0/>"
-msgstr ""
+msgstr "Rompi alleanza con <0/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:316
 msgid "Break an alliance with another country"
@@ -1792,7 +1792,7 @@ msgstr "Sciogli un'alleanza con un altro paese"
 
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:114
 msgid "Break room"
-msgstr ""
+msgstr "Sala pausa"
 
 #: src/components/_political/law/law.frontConfig.tsx:329
 msgid "Break the alliance with <0/>"
@@ -1808,7 +1808,7 @@ msgstr "Sfoglia i pacchetti"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:153
 msgid "Budget"
-msgstr ""
+msgstr "Budget"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2027
 msgid "Buff ended"
@@ -1816,7 +1816,7 @@ msgstr "Buff terminato"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2025
 msgid "Buff expiring soon"
-msgstr ""
+msgstr "Buff in scadenza"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2023
 msgid "Buff started"
@@ -1824,11 +1824,11 @@ msgstr "Buff iniziato"
 
 #: src/components/_user/user/SkillValue.tsx:168
 msgid "Buffs:"
-msgstr ""
+msgstr "Buff:"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:123
 msgid "Bug finder"
-msgstr ""
+msgstr "Cacciatore di bug"
 
 #: src/components/_economy/company/CompanyList.tsx:152
 msgid "Build a company"
@@ -1844,12 +1844,12 @@ msgstr "Crea l'unità militare"
 
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:31
 msgid "Bunker"
-msgstr ""
+msgstr "Bunker"
 
 #. placeholder {0}: law.data.amount ?? 0
 #: src/components/_political/law/law.frontConfig.tsx:408
 msgid "Buy <0/> from <1/> for <2>{0}</2>"
-msgstr ""
+msgstr "Acquista <0/> da <1/> per <2>{0}</2>"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:168
 msgid "Buy for <0>{count}</0> money on market"
@@ -1866,7 +1866,7 @@ msgstr "Ordini di acquisto"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:359
 msgid "By continuing, you agree to our <0>Terms of Service</0>."
-msgstr ""
+msgstr "Continuando, accetti i nostri <0>Termini di servizio</0>."
 
 #. placeholder {0}: worker.fidelity ?? 0
 #: src/components/_user/worker/WageReductionAlert.tsx:56
@@ -1875,7 +1875,7 @@ msgstr "Rifiutando la riduzione del salario, lascerai l'azienda e perderai il tu
 
 #: src/components/_military/damageRanking/DamageRankingSides.tsx:150
 msgid "By side"
-msgstr ""
+msgstr "Per fazione"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:26
 msgid "Cadet"
@@ -1891,7 +1891,7 @@ msgstr "Annulla"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItem.tsx:77
 msgid "Cancel as gov"
-msgstr ""
+msgstr "Annulla come governo"
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:166
 msgid "Cancel at any time"
@@ -1900,30 +1900,30 @@ msgstr "Annulla in qualsiasi momento"
 #: src/components/_military/mercenaryContract/AdminDeleteContractModal.tsx:43
 #: src/components/_military/mercenaryContract/AdminDeleteContractModal.tsx:64
 msgid "Cancel Contract"
-msgstr ""
+msgstr "Annulla contratto"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItem.tsx:84
 #: src/components/_military/mercenaryContract/MercenaryContractModal.tsx:63
 #: src/components/_military/mercenaryContract/MercenaryContractModal.tsx:75
 msgid "Cancel Mercenary Contract"
-msgstr ""
+msgstr "Annulla contratto mercenario"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:232
 #: src/utils/translations.tsx:253
 msgid "Cancelled"
-msgstr ""
+msgstr "Annullato"
 
 #: src/utils/translations.tsx:254
 msgid "Cancelled by admin"
-msgstr ""
+msgstr "Annullato dall'amministratore"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:238
 msgid "Cancelled by Admin"
-msgstr ""
+msgstr "Annullato dall'Amministratore"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:133
 msgid "Candidacy is open for <0/>"
-msgstr ""
+msgstr "Le candidature sono aperte per <0/>"
 
 #: src/components/_political/election/CandidateFormModal.tsx:86
 msgid "Candidate"
@@ -1979,7 +1979,7 @@ msgstr "Catapulta"
 
 #: src/components/_user/user/skills.frontConfig.tsx:152
 msgid "Chance per hit to instantly loot:<0/>Each <1>1%</1> gives<2>1%</2> and <3>0.01%</3> to loot cases per hit."
-msgstr ""
+msgstr "Probabilità per colpo di saccheggiare istantaneamente:<0/>Ogni <1>1%</1> dà<2>1%</2> e <3>0,01%</3> di probabilità di saccheggiare casse per colpo."
 
 #: src/components/_user/user/skills.frontConfig.tsx:138
 msgid "Chance to dodge all incoming damage when fighting in battles.<0/>Dodging also prevents equipment durability from being consumed."
@@ -1992,7 +1992,7 @@ msgstr "Probabilità di colpire il bersaglio.<0/>I colpi mancati non possono cri
 #. placeholder {0}: law.data.taxType
 #: src/components/_political/law/law.frontConfig.tsx:62
 msgid "Change {0} tax to <0/>"
-msgstr ""
+msgstr "Modifica la tassa {0} a <0/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:58
 msgid "Change a country tax"
@@ -2174,7 +2174,7 @@ msgstr "Comandante"
 #: src/components/_user/notification/notification.frontConfig.tsx:1869
 #: src/components/_user/notification/notification.frontConfig.tsx:1882
 msgid "Commission earned"
-msgstr ""
+msgstr "Commissione guadagnata"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:116
 msgid "Commodore"
@@ -2182,7 +2182,7 @@ msgstr "Commodoro"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:141
 msgid "Community"
-msgstr ""
+msgstr "Comunità"
 
 #: src/components/_layout/LayoutMenu.tsx:184
 #: src/components/_user/user/MyAvatar.tsx:48
@@ -2236,7 +2236,7 @@ msgstr "Completa missioni ogni giorno per guadagnare XP e salire di livello più
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:234
 #: src/utils/translations.tsx:256
 msgid "Completed"
-msgstr ""
+msgstr "Completato"
 
 #: src/utils/translations.tsx:29
 msgid "Concrete"
@@ -2314,7 +2314,7 @@ msgstr "Il congresso ha un minimo di <0>{0} seggi</0>."
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:57
 msgid "Congress Member"
-msgstr ""
+msgstr "Membro del Congresso"
 
 #: src/pages/country/[countryId]/government.tsx:64
 msgid "Congress members"
@@ -2326,11 +2326,11 @@ msgstr "Connetti con Discord"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:305
 msgid "Connect with email code"
-msgstr ""
+msgstr "Connetti con codice email"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:343
 msgid "Connect with Google"
-msgstr ""
+msgstr "Connetti con Google"
 
 #: src/pages/country/[countryId]/regions.tsx:43
 msgid "Conquered regions"
@@ -2338,7 +2338,7 @@ msgstr "Regioni conquistate"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:91
 msgid "Conqueror"
-msgstr ""
+msgstr "Conquistatore"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:69
 msgid "Consider giving it to your local moderator"
@@ -2360,19 +2360,19 @@ msgstr "Bordi contestuali"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2014
 msgid "Contract cancelled"
-msgstr ""
+msgstr "Contratto annullato"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2011
 msgid "Contract completed"
-msgstr ""
+msgstr "Contratto completato"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2017
 msgid "Contract expired"
-msgstr ""
+msgstr "Contratto scaduto"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2020
 msgid "Contract rolled back"
-msgstr ""
+msgstr "Contratto annullato"
 
 #: src/components/_military/battle/BattleHeader.tsx:312
 #: src/components/_military/battle/BattlesHeader.tsx:43
@@ -2380,11 +2380,11 @@ msgstr ""
 #: src/components/_military/battle/LootSummaryCard.tsx:96
 #: src/components/_political/country/CountryHeader.tsx:132
 msgid "Contracts"
-msgstr ""
+msgstr "Contratti"
 
 #: src/components/_military/battle/BattleSideContractsModal.tsx:29
 msgid "Contracts & Auctions"
-msgstr ""
+msgstr "Contratti e aste"
 
 #: src/utils/translations.tsx:39
 msgid "Cooked Fish"
@@ -2397,7 +2397,7 @@ msgstr "Tempo di recupero"
 
 #: src/components/_user/badgeCollection/Badge.tsx:70
 msgid "Cooldown: {cooldownDays} days"
-msgstr ""
+msgstr "Cooldown: {cooldownDays} giorni"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:90
 msgid "Copied to clipboard"
@@ -2425,7 +2425,7 @@ msgstr "Costo"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:223
 msgid "Council Member"
-msgstr ""
+msgstr "Membro del Consiglio"
 
 #: src/components/_political/partyMotion/PartyMotionFormModal.tsx:134
 msgid "Council member to remove"
@@ -2453,16 +2453,16 @@ msgstr "Bonus reddito da sviluppo del paese"
 
 #: src/components/_military/battle/BattleSideOrdersModal.tsx:40
 msgid "Country Orders"
-msgstr ""
+msgstr "Ordini del paese"
 
 #. placeholder {0}: data.partialPayout
 #: src/components/_user/notification/notification.frontConfig.tsx:1549
 msgid "Country paid <0>{0}</0> for damages done."
-msgstr ""
+msgstr "Il paese ha pagato <0>{0}</0> per i danni inflitti."
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:51
 msgid "Country President"
-msgstr ""
+msgstr "Presidente del paese"
 
 #: src/pages/country/[countryId]/index.tsx:434
 msgid "Country production bonus"
@@ -2470,7 +2470,7 @@ msgstr "Bonus produzione del paese"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:181
 msgid "Country Tournament Winner"
-msgstr ""
+msgstr "Vincitore del torneo nazionale"
 
 #: src/pages/country/[countryId]/wars.tsx:29
 msgid "Country wars"
@@ -2512,15 +2512,15 @@ msgstr "Crea token API"
 
 #: src/components/_military/battle/BattleOrderActionsDropdown.tsx:106
 msgid "Create auction"
-msgstr ""
+msgstr "Crea asta"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:233
 msgid "Create Auction"
-msgstr ""
+msgstr "Crea Asta"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:132
 msgid "Create Mercenary Auction"
-msgstr ""
+msgstr "Crea asta mercenaria"
 
 #: src/components/_political/party/PartyFormModal.tsx:130
 msgid "Create party"
@@ -2582,11 +2582,11 @@ msgstr "Reset missioni giornaliere"
 
 #: src/components/_political/government/Government.tsx:174
 msgid "Daily wage paid from the country treasury."
-msgstr ""
+msgstr "Salario giornaliero pagato dal tesoro nazionale."
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:156
 msgid "Damage by user"
-msgstr ""
+msgstr "Danno per utente"
 
 #: src/components/_military/damageRanking/DamageRankingSides.tsx:114
 msgid "Damage ranking"
@@ -2600,7 +2600,7 @@ msgstr "Danni"
 
 #: src/components/_military/mu/MuMemberList.tsx:345
 msgid "Damages for Mu"
-msgstr ""
+msgstr "Danni per l'UM"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:17
 msgid "Damn looks good"
@@ -2620,11 +2620,11 @@ msgstr "Scuro"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:25
 msgid "Dark Era"
-msgstr ""
+msgstr "Era Oscura"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:24
 msgid "Dark Era Pack"
-msgstr ""
+msgstr "Pack Era Oscura"
 
 #: src/components/_layout/LayoutMapOptions.tsx:281
 msgid "Dark map"
@@ -2648,7 +2648,7 @@ msgstr "Infliggi danni nelle battaglie per aumentare il tuo grado militare e sbl
 
 #: src/components/_military/mu/MuLevelsInfoModal.tsx:118
 msgid "Deal damage in battles with your MU members to level up each month and earn rewards. Resets on the 1st of each month."
-msgstr ""
+msgstr "Infliggi danni nelle battaglie con i membri della tua UM per salire di livello ogni mese e guadagnare ricompense. Si azzera il 1° di ogni mese."
 
 #: src/components/_user/mission/mission.frontConfig.tsx:100
 msgid "Deal Damages"
@@ -2688,7 +2688,7 @@ msgstr "Debuff terminato"
 
 #: src/components/_user/user/SkillValue.tsx:200
 msgid "Debuffs:"
-msgstr ""
+msgstr "Debuff:"
 
 #: src/components/_political/law/law.frontConfig.tsx:111
 #: src/components/_political/law/lawNames.tsx:14
@@ -2711,11 +2711,11 @@ msgstr "Rifiuta e lascia"
 #: src/components/_political/unrest/UnrestPanel.tsx:143
 #: src/components/_political/unrest/UnrestPanel.tsx:179
 msgid "Decrease"
-msgstr ""
+msgstr "Diminuisci"
 
 #: src/components/_political/unrest/UnrestPanel.tsx:110
 msgid "Decrease unrest"
-msgstr ""
+msgstr "Diminuisci il malcontento"
 
 #: src/components/_military/hit/HitButton.tsx:457
 msgid "Defend"
@@ -2736,7 +2736,7 @@ msgstr "Definisci <0/> come nemico, aumentando i danni quando lo combatti"
 
 #: src/components/_political/law/law.frontConfig.tsx:215
 msgid "Define <0/> as enemy"
-msgstr ""
+msgstr "Definisci <0/> come nemico"
 
 #: src/components/_political/law/law.frontConfig.tsx:211
 msgid "Define a country as an enemy to get bonus against"
@@ -2753,7 +2753,7 @@ msgstr "Elimina account"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItem.tsx:100
 msgid "Delete contract"
-msgstr ""
+msgstr "Elimina contratto"
 
 #: src/pages/index.tsx:146
 #: src/pages/rules.tsx:40
@@ -2762,11 +2762,11 @@ msgstr "Elimina il tuo account"
 
 #: src/components/_military/mu/MuMemberList.tsx:153
 msgid "Demote Commander"
-msgstr ""
+msgstr "Retrocedi Comandante"
 
 #: src/components/_military/mu/MuMemberList.tsx:440
 msgid "Demote from Commander"
-msgstr ""
+msgstr "Retrocedi da Comandante"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1999
 msgid "Demoted from Commander"
@@ -2787,7 +2787,7 @@ msgstr "Giacimento scoperto"
 #. placeholder {0}: ts[data.itemCode]
 #: src/components/_political/event/event.frontConfig.tsx:284
 msgid "Deposit of <0>{0}</0> has been depleted in <1/>"
-msgstr ""
+msgstr "Il giacimento di <0>{0}</0> si è esaurito in <1/>"
 
 #: src/pages/region/[regionId]/index.tsx:56
 msgid "Deposit resource"
@@ -2834,11 +2834,11 @@ msgstr "Sviluppo"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:290
 msgid "Diminish <0/> received damages with <1>Armor</1> in battles"
-msgstr ""
+msgstr "Riduci i danni ricevuti da <0/> con l'<1>Armatura</1> nelle battaglie"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:288
 msgid "Diminish Received Damages"
-msgstr ""
+msgstr "Riduci i danni ricevuti"
 
 #: src/pages/country/[countryId]/index.tsx:191
 msgid "Diplomacy"
@@ -2880,7 +2880,7 @@ msgstr "Chiudi"
 
 #: src/components/_military/damageRanking/BattleLoot.tsx:97
 msgid "Distributed"
-msgstr ""
+msgstr "Distribuito"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:10
 msgid "Do you even know what luck is?"
@@ -2937,11 +2937,11 @@ msgstr "Donazioni"
 
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:101
 msgid "Dormitories"
-msgstr ""
+msgstr "Dormitori"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:152
 msgid "Dragon"
-msgstr ""
+msgstr "Drago"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:130
 msgid "Eat"
@@ -2966,7 +2966,7 @@ msgstr "Mangia bistecca"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:20
 msgid "Eco Mode"
-msgstr ""
+msgstr "Modalità Eco"
 
 #: src/components/_political/law/LawTypeSelect.tsx:108
 msgid "Economic laws"
@@ -2978,7 +2978,7 @@ msgstr "Abilità economiche"
 
 #: src/components/_user/notification/notificationPrefs.categories.ts:154
 msgid "Economy & Companies"
-msgstr ""
+msgstr "Economia e aziende"
 
 #: src/components/_user/user/UserDropdown.tsx:209
 msgid "Edit description"
@@ -2994,19 +2994,19 @@ msgstr "Modifica lavoratore"
 
 #: src/components/_user/user/SkillValue.tsx:230
 msgid "Effective:"
-msgstr ""
+msgstr "Efficace:"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1906
 msgid "Election candidacy open"
-msgstr ""
+msgstr "Candidatura elettorale aperta"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1911
 msgid "Election ended"
-msgstr ""
+msgstr "Elezione terminata"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1909
 msgid "Election vote open"
-msgstr ""
+msgstr "Votazione elettorale aperta"
 
 #: src/components/_political/country/CountryHeader.tsx:105
 #: src/pages/country/[countryId]/elections.tsx:28
@@ -3060,7 +3060,7 @@ msgstr "Costo di attuazione"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:185
 msgid "Enchanted Trousers"
-msgstr ""
+msgstr "Pantaloni Incantati"
 
 #: src/components/_military/battle/BattleSystem.tsx:737
 msgid "Ended"
@@ -3110,7 +3110,7 @@ msgstr "Equipaggiamento"
 
 #: src/components/_user/user/SkillValue.tsx:73
 msgid "Equipment:"
-msgstr ""
+msgstr "Equipaggiamento:"
 
 #: src/components/_economy/market/MarketHeader.tsx:26
 msgid "Equipments"
@@ -3128,7 +3128,7 @@ msgstr "Beneficio stimato per"
 #: src/components/_military/battle/BattleSystem.tsx:460
 #: src/components/_military/battle/BattleSystem.tsx:497
 msgid "Estimated minimum time for this side to win the current round if all ticks are won."
-msgstr ""
+msgstr "Tempo minimo stimato per questa fazione per vincere il round corrente se tutti i tick vengono vinti."
 
 #: src/pages/party/[partyId]/index.tsx:57
 msgid "Ethics"
@@ -3160,19 +3160,19 @@ msgstr "Tutti partecipano automaticamente"
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:236
 #: src/utils/translations.tsx:257
 msgid "Expired"
-msgstr ""
+msgstr "Scaduto"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:66
 msgid "Expired: battle ended"
-msgstr ""
+msgstr "Scaduto: battaglia terminata"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:64
 msgid "Expired: no bids"
-msgstr ""
+msgstr "Scaduto: nessuna offerta"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:68
 msgid "Expired: round ended"
-msgstr ""
+msgstr "Scaduto: round terminato"
 
 #: src/pages/region/[regionId]/index.tsx:79
 msgid "Expires in"
@@ -3180,7 +3180,7 @@ msgstr "Scade tra"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:217
 msgid "Exploit Finder"
-msgstr ""
+msgstr "Cacciatore di exploit"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:92
 msgid "Failed to copy"
@@ -3200,11 +3200,11 @@ msgstr "Impossibile avviare l'accesso con Discord. Riprova il CAPTCHA."
 
 #: src/components/_user/auth/ConnectFromModal.tsx:126
 msgid "Failed to start Google login."
-msgstr ""
+msgstr "Impossibile avviare il login con Google."
 
 #: src/components/_user/auth/ConnectFromModal.tsx:124
 msgid "Failed to start Google login. Please retry the CAPTCHA."
-msgstr ""
+msgstr "Impossibile avviare il login con Google. Riprova il CAPTCHA."
 
 #: src/components/_user/user/FamilyGroup.tsx:60
 msgid "Family Group"
@@ -3244,31 +3244,31 @@ msgstr "Fanatico Repubblicano"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:21
 msgid "Farmer"
-msgstr ""
+msgstr "Contadino"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:143
 msgid "Farmer Boots"
-msgstr ""
+msgstr "Stivali del Contadino"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:140
 msgid "Farmer Chest"
-msgstr ""
+msgstr "Corazza del Contadino"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:149
 msgid "Farmer Gloves"
-msgstr ""
+msgstr "Guanti del Contadino"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:137
 msgid "Farmer Helmet"
-msgstr ""
+msgstr "Elmo del Contadino"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:134
 msgid "Farmer Knife"
-msgstr ""
+msgstr "Coltello del Contadino"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:146
 msgid "Farmer Pants"
-msgstr ""
+msgstr "Pantaloni del Contadino"
 
 #: src/components/_military/battle/ActiveBattlesList.tsx:87
 #: src/components/_military/battle/ActiveBattlesList.tsx:167
@@ -3278,7 +3278,7 @@ msgstr "Preferiti"
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:231
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:108
 msgid "Fee"
-msgstr ""
+msgstr "Commissione"
 
 #: src/components/_layout/LayoutRightIcons.tsx:335
 #: src/components/_layout/MoreButtonNav.tsx:86
@@ -3295,11 +3295,11 @@ msgstr "Bonus fedeltà:"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:152
 msgid "Fight for <0/> in <1/>"
-msgstr ""
+msgstr "Combatti per <0/> in <1/>"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:62
 msgid "Fight for <0/> in<1/><2/>"
-msgstr ""
+msgstr "Combatti per <0/> in<1/><2/>"
 
 #: src/components/_user/user/skills.frontConfig.tsx:201
 msgid "Fight skills"
@@ -3348,7 +3348,7 @@ msgstr "Finanzia una resistenza locale"
 
 #: src/components/_political/law/law.frontConfig.tsx:555
 msgid "Finance resistance in <0/>"
-msgstr ""
+msgstr "Finanzia la resistenza in <0/>"
 
 #: src/pages/companies.tsx:59
 #: src/pages/user/[userId]/companies.tsx:73
@@ -3398,7 +3398,7 @@ msgstr "Bandiere"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:155
 msgid "Flail"
-msgstr ""
+msgstr "Flagello"
 
 #: src/components/_layout/LayoutMapOptions.tsx:337
 msgid "Font"
@@ -3419,7 +3419,7 @@ msgstr "per aziende che producono <0>{0}</0> situate in <1/>."
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:45
 msgid "Founding Father"
-msgstr ""
+msgstr "Padre Fondatore"
 
 #: src/pages/shop/index.tsx:129
 msgid "Free daily reward"
@@ -3435,7 +3435,7 @@ msgstr "Ottieni <0>XP</0> completando le tue missioni!"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:109
 msgid "Game supporter"
-msgstr ""
+msgstr "Sostenitore del gioco"
 
 #: src/pages/shop/index.tsx:139
 msgid "Gems"
@@ -3456,11 +3456,11 @@ msgstr "Genera missioni"
 #. placeholder {0}: levelConfig.stats.dailyProd
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:72
 msgid "Generates <0>{0}</0>/day"
-msgstr ""
+msgstr "Genera <0>{0}</0>/giorno"
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:46
 msgid "Get an exclusive <0>subscriber skin</0>!"
-msgstr ""
+msgstr "Ottieni una <0>skin esclusiva per abbonati</0>!"
 
 #: src/components/_other/shop/SkinCollectionModal.tsx:94
 msgid "Get multiple skins at once with a 30% discount!"
@@ -3496,7 +3496,7 @@ msgstr "regalato"
 
 #: src/components/_military/mu/MuMemberList.tsx:446
 msgid "Give Ownership"
-msgstr ""
+msgstr "Trasferisci proprietà"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:251
 msgid "Give your token a descriptive name so you can identify it later."
@@ -3504,7 +3504,7 @@ msgstr "Dai al tuo token un nome descrittivo così potrai riconoscerlo più tard
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:193
 msgid "Giveaway Winner"
-msgstr ""
+msgstr "Vincitore del giveaway"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2040
 msgid "Giveaway Won!"
@@ -3513,7 +3513,7 @@ msgstr "Giveaway vinto!"
 #. placeholder {0}: levelConfig.stats.attackBonus
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:92
 msgid "Gives <0>{0}</0>"
-msgstr ""
+msgstr "Fornisce <0>{0}</0>"
 
 #: src/components/_layout/LayoutMapOptions.tsx:218
 msgid "Globe (experimental)"
@@ -3546,15 +3546,15 @@ msgstr "Governo"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:234
 msgid "Government Member"
-msgstr ""
+msgstr "Membro del governo"
 
 #: src/components/_military/battle/BattleSystem.tsx:804
 msgid "Government penalty"
-msgstr ""
+msgstr "Penalità governativa"
 
 #: src/components/_political/government/Government.tsx:185
 msgid "Government wage"
-msgstr ""
+msgstr "Stipendio governativo"
 
 #: src/utils/translations.tsx:28
 msgid "Grain"
@@ -3570,71 +3570,71 @@ msgstr "Ottimo lavoro! Colpisci ancora qualche volta per aiutare la tua fazione 
 
 #: src/components/_other/shop/skin.frontConfig.tsx:158
 msgid "Green Staff"
-msgstr ""
+msgstr "Bastone Verde"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:29
 msgid "Grimdark"
-msgstr ""
+msgstr "Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:215
 msgid "Grimdark Ammo"
-msgstr ""
+msgstr "Munizioni Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:227
 msgid "Grimdark Boots"
-msgstr ""
+msgstr "Stivali Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:224
 msgid "Grimdark Chest"
-msgstr ""
+msgstr "Corazza Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:233
 msgid "Grimdark Gloves"
-msgstr ""
+msgstr "Guanti Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:197
 msgid "Grimdark Gun"
-msgstr ""
+msgstr "Pistola Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:218
 msgid "Grimdark Heavy Ammo"
-msgstr ""
+msgstr "Munizioni Pesanti Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:221
 msgid "Grimdark Helmet"
-msgstr ""
+msgstr "Elmo Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:209
 msgid "Grimdark Jet"
-msgstr ""
+msgstr "Jet Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:194
 msgid "Grimdark Knife"
-msgstr ""
+msgstr "Coltello Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:212
 msgid "Grimdark Light Ammo"
-msgstr ""
+msgstr "Munizioni Leggere Grimdark"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:28
 msgid "Grimdark Pack"
-msgstr ""
+msgstr "Pack Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:230
 msgid "Grimdark Pants"
-msgstr ""
+msgstr "Pantaloni Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:200
 msgid "Grimdark Rifle"
-msgstr ""
+msgstr "Fucile Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:203
 msgid "Grimdark Sniper"
-msgstr ""
+msgstr "Cecchino Grimdark"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:206
 msgid "Grimdark Tank"
-msgstr ""
+msgstr "Carro Armato Grimdark"
 
 #: src/components/_user/user/UserRankingsPanel.tsx:33
 msgid "Ground"
@@ -3654,15 +3654,15 @@ msgstr "Pistola"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:236
 msgid "Hamster Tank"
-msgstr ""
+msgstr "Carro Armato Criceto"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:85
 msgid "Hard Worker"
-msgstr ""
+msgstr "Gran Lavoratore"
 
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:89
 msgid "Headquarters"
-msgstr ""
+msgstr "Quartier Generale"
 
 #: src/components/_user/user/skills.frontConfig.tsx:79
 #: src/components/_user/user/skills.frontConfig.tsx:80
@@ -3684,7 +3684,7 @@ msgstr "Aiuta <0>{count}</0> membri UM"
 
 #: src/components/_military/mu/MuMemberList.tsx:375
 msgid "Help for Mu"
-msgstr ""
+msgstr "Aiuto per l'UM"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:250
 msgid "Help MU Members"
@@ -3713,7 +3713,7 @@ msgstr "Colpisci <0>{count}</0> volte nelle battaglie"
 #. placeholder {0}: staticGameConfig.battle.govMemberBountyRewardPercent
 #: src/components/_military/battle/BattleSystem.tsx:806
 msgid "Hitting for your own country while in government gives {0}% bounty efficiency."
-msgstr ""
+msgstr "Combattere per il proprio paese mentre si è nel governo dà {0}% di efficienza taglia."
 
 #: src/components/_other/shop/ShopHeader.tsx:16
 #: src/components/_political/country/CountryHeader.tsx:61
@@ -3744,11 +3744,11 @@ msgstr "Sono fiero di te"
 
 #: src/components/_military/mercenaryContract/MercenaryReputationTooltip.tsx:39
 msgid "If negative, pay <0/> for <1/> (once per day)."
-msgstr ""
+msgstr "Se negativo, paga <0/> per <1/> (una volta al giorno)."
 
 #: src/components/_political/government/NominateForm.tsx:58
 msgid "If the new nominee is already in government, their positions will be swapped. Otherwise the current member will be fired and won't be able to be nominated again for {cooldownDays} days."
-msgstr ""
+msgstr "Se il nuovo nominato è già nel governo, le loro posizioni verranno scambiate. Altrimenti il membro attuale verrà licenziato e non potrà essere nominato di nuovo per {cooldownDays} giorni."
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:51
 msgid "Imagine if you stop right before the Mythic"
@@ -3760,7 +3760,7 @@ msgstr "Immagina sprecare il tuo click su questo"
 
 #: src/components/_political/law/law.frontConfig.tsx:187
 msgid "Impeach <0/>"
-msgstr ""
+msgstr "Destituisci <0/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:181
 #: src/components/_political/law/lawNames.tsx:22
@@ -3833,11 +3833,11 @@ msgstr "Imposta sul reddito"
 #: src/components/_political/unrest/UnrestPanel.tsx:143
 #: src/components/_political/unrest/UnrestPanel.tsx:179
 msgid "Increase"
-msgstr ""
+msgstr "Aumenta"
 
 #: src/components/_political/unrest/UnrestPanel.tsx:109
 msgid "Increase unrest"
-msgstr ""
+msgstr "Aumenta il malcontento"
 
 #: src/components/_political/party/party.frontConfig.tsx:316
 msgid "Industrialism vs Agrarianism"
@@ -3850,7 +3850,7 @@ msgstr "Industrialista"
 
 #: src/components/_political/government/Government.tsx:181
 msgid "Initial development"
-msgstr ""
+msgstr "Sviluppo iniziale"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:11
 msgid "Initiate"
@@ -3900,7 +3900,7 @@ msgstr "Mercato oggetti"
 
 #: src/components/_user/user/WealthPanel.tsx:49
 msgid "Items"
-msgstr ""
+msgstr "Oggetti"
 
 #: src/pages/companies.tsx:32
 #: src/pages/user/[userId]/companies.tsx:56
@@ -3970,11 +3970,11 @@ msgstr "Resta nell'azienda attuale"
 
 #: src/components/_military/mu/MuMemberList.tsx:428
 msgid "Kick"
-msgstr ""
+msgstr "Espelli"
 
 #: src/components/_military/mu/MuMemberList.tsx:139
 msgid "Kick Member"
-msgstr ""
+msgstr "Espelli membro"
 
 #: src/utils/translations.tsx:22
 msgid "Knife"
@@ -3995,11 +3995,11 @@ msgstr "Lingua"
 
 #: src/components/_military/damageRanking/BattleLoot.tsx:116
 msgid "Last"
-msgstr ""
+msgstr "Ultimo"
 
 #: src/components/_user/badgeCollection/Badge.tsx:63
 msgid "Last earned: <0/>"
-msgstr ""
+msgstr "Ultimo guadagnato: <0/>"
 
 #: src/pages/shop/index.tsx:89
 msgid "Last gifts"
@@ -4009,7 +4009,7 @@ msgstr "Ultimi regali"
 #: src/components/_user/auth/ConnectFromModal.tsx:327
 #: src/components/_user/auth/ConnectFromModal.tsx:346
 msgid "Last used"
-msgstr ""
+msgstr "Ultimo utilizzo"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:192
 msgid "Last used:"
@@ -4099,7 +4099,7 @@ msgstr "Pantaloni leggendari"
 #: src/components/_military/mu/MuLevel.tsx:64
 #: src/components/_military/mu/MuLevelsInfoModal.tsx:89
 msgid "Level {level}"
-msgstr ""
+msgstr "Livello {level}"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:107
 msgid "Level up your skills!"
@@ -4111,7 +4111,7 @@ msgstr "Livello aumentato!"
 
 #: src/components/_political/law/law.frontConfig.tsx:435
 msgid "Liberate <0/>"
-msgstr ""
+msgstr "Libera <0/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:444
 msgid "Liberate <0/> and return it to its original country"
@@ -4160,7 +4160,7 @@ msgstr "Limite di consumo di cibo"
 
 #: src/components/_user/user/SkillValue.tsx:88
 msgid "Limited:"
-msgstr ""
+msgstr "Limitato:"
 
 #: src/components/_layout/LayoutMapOptions.tsx:324
 msgid "Line"
@@ -4221,11 +4221,11 @@ msgstr "Probabilità bottino"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1967
 msgid "Loot reward"
-msgstr ""
+msgstr "Ricompensa bottino"
 
 #: src/components/_military/damageRanking/BattleLoot.tsx:130
 msgid "Loots"
-msgstr ""
+msgstr "Bottini"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:20
 msgid "Love Paper Jet"
@@ -4245,7 +4245,7 @@ msgstr "La fortuna è finalmente a libro paga"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:188
 msgid "Mage Robe"
-msgstr ""
+msgstr "Veste del Mago"
 
 #: src/components/_political/law/Law.tsx:96
 msgid "Maintenance cost"
@@ -4295,18 +4295,18 @@ msgstr "Maresciallo"
 
 #: src/components/_military/mu/MuLevel.tsx:81
 msgid "Max level reached!"
-msgstr ""
+msgstr "Livello massimo raggiunto!"
 
 #. placeholder {0}: levelConfig.stats.members
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:104
 msgid "Maximum of <0>{0}</0> members."
-msgstr ""
+msgstr "Massimo di <0>{0}</0> membri."
 
 #. placeholder {0}: levelConfig.stats.maxWorkers
 #. placeholder {1}: typeof levelConfig.stats.dailyHires !== 'undefined' && ( <> <br /> Daily hiring limit of{' '} <EntityValue IconComponent={WorkerIcon}> {levelConfig.stats.dailyHires} </EntityValue>{' '} per day. </> )
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:117
 msgid "Maximum of <0>{0}</0> workers.{1}"
-msgstr ""
+msgstr "Massimo di <0>{0}</0> lavoratori.{1}"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:32
 msgid "Maybe epic music would help?"
@@ -4370,15 +4370,15 @@ msgstr "Richieste di iscrizione"
 
 #: src/components/_military/mu/MuMemberList.tsx:116
 msgid "Member demoted from commander"
-msgstr ""
+msgstr "Membro retrocesso da comandante"
 
 #: src/components/_military/mu/MuMemberList.tsx:108
 msgid "Member kicked successfully"
-msgstr ""
+msgstr "Membro espulso con successo"
 
 #: src/components/_military/mu/MuMemberList.tsx:112
 msgid "Member promoted to commander"
-msgstr ""
+msgstr "Membro promosso a comandante"
 
 #: src/pages/party/[partyId]/index.tsx:75
 #: src/pages/party/[partyId]/members.tsx:21
@@ -4392,25 +4392,25 @@ msgstr "Menzionato in un messaggio"
 #: src/pages/country/[countryId]/auctions.tsx:25
 #: src/pages/country/[countryId]/index.tsx:392
 msgid "Mercenary Auctions"
-msgstr ""
+msgstr "Aste mercenarie"
 
 #: src/pages/country/[countryId]/contracts.tsx:25
 #: src/pages/country/[countryId]/index.tsx:380
 #: src/pages/mu/[muId]/contracts.tsx:24
 msgid "Mercenary Contracts"
-msgstr ""
+msgstr "Contratti mercenari"
 
 #: src/components/_military/mercenaryContract/MercenaryContractsDisabled.tsx:11
 msgid "Mercenary contracts are currently disabled."
-msgstr ""
+msgstr "I contratti mercenari sono attualmente disabilitati."
 
 #: src/components/_military/battle/LootSummaryCard.tsx:90
 msgid "Mercenary earnings"
-msgstr ""
+msgstr "Guadagni mercenari"
 
 #: src/components/_military/mercenaryContract/MercenaryReputationTooltip.tsx:15
 msgid "Mercenary Reputation"
-msgstr ""
+msgstr "Reputazione mercenaria"
 
 #: src/components/_other/shop/SkinPackModal.tsx:237
 msgid "Message (Optional)"
@@ -4431,11 +4431,11 @@ msgstr "Militarista"
 
 #: src/components/_user/notification/notificationPrefs.categories.ts:158
 msgid "Military & Battles"
-msgstr ""
+msgstr "Militare e battaglie"
 
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:43
 msgid "Military base"
-msgstr ""
+msgstr "Base militare"
 
 #: src/components/_political/law/LawTypeSelect.tsx:73
 msgid "Military laws"
@@ -4451,7 +4451,7 @@ msgstr "Grado militare aumentato!"
 
 #: src/components/_user/user/SkillValue.tsx:184
 msgid "Military rank:"
-msgstr ""
+msgstr "Grado militare:"
 
 #: src/components/_user/user/MilitaryRanksInfoModal.tsx:88
 msgid "Military Ranks"
@@ -4472,11 +4472,11 @@ msgstr "Unità militari"
 
 #: src/components/_military/battle/BattleCountrySide.tsx:92
 msgid "Military Units"
-msgstr ""
+msgstr "Unità militari"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:286
 msgid "Min reached"
-msgstr ""
+msgstr "Minimo raggiunto"
 
 #: src/components/_political/law/Law.tsx:118
 msgid "Min. active citizens"
@@ -4502,11 +4502,11 @@ msgstr "Missioni"
 
 #: src/components/_user/modals/PhoneVerificationModal.tsx:123
 msgid "Mobile phone number"
-msgstr ""
+msgstr "Numero di telefono mobile"
 
 #: src/components/_user/user/WealthPanel.tsx:35
 msgid "Money"
-msgstr ""
+msgstr "Denaro"
 
 #: src/components/_military/damageRanking/DamageRankingSides.tsx:135
 msgid "Money earned from mercenary contracts."
@@ -4530,16 +4530,16 @@ msgstr "Denaro vinto"
 
 #: src/components/_military/mu/MuMemberList.tsx:191
 msgid "Monthly"
-msgstr ""
+msgstr "Mensile"
 
 #: src/components/_military/mu/MuLevel.tsx:107
 msgid "Monthly damages: <0>{monthlyDamages}</0>"
-msgstr ""
+msgstr "Danni mensili: <0>{monthlyDamages}</0>"
 
 #: src/components/_military/mu/MuMemberList.tsx:355
 #: src/components/_military/mu/MuMemberList.tsx:390
 msgid "Monthly:"
-msgstr ""
+msgstr "Mensile:"
 
 #: src/components/_layout/MoreButtonNav.tsx:194
 msgid "More"
@@ -4606,15 +4606,15 @@ msgstr "Donazione UM ricevuta"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1991
 msgid "MU Level Up!"
-msgstr ""
+msgstr "Livello UM aumentato!"
 
 #: src/components/_military/mu/MuLevelsInfoModal.tsx:112
 msgid "MU Monthly Levels"
-msgstr ""
+msgstr "Livelli mensili UM"
 
 #: src/components/_military/battle/BattleSideOrdersModal.tsx:59
 msgid "MU Orders"
-msgstr ""
+msgstr "Ordini UM"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2002
 msgid "MU Ownership Transferred"
@@ -4623,15 +4623,15 @@ msgstr "Proprietà UM trasferita"
 #. placeholder {0}: data.level
 #: src/components/_political/message/systemMessage.frontConfig.tsx:103
 msgid "MU reached level {0}! Reward: {rewardDisplay}"
-msgstr ""
+msgstr "L'UM ha raggiunto il livello {0}! Ricompensa: {rewardDisplay}"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:187
 msgid "MU Tournament Winner"
-msgstr ""
+msgstr "Vincitore del torneo UM"
 
 #: src/components/_military/battle/LootSummaryCard.tsx:121
 msgid "My battle loot"
-msgstr ""
+msgstr "Il mio bottino di battaglia"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:247
 msgid "My Bot, Script, etc."
@@ -4676,7 +4676,7 @@ msgstr "Nome"
 
 #: src/components/_military/battle/BattleSystem.tsx:792
 msgid "National bounty"
-msgstr ""
+msgstr "Taglia nazionale"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:56
 msgid "Need a job?"
@@ -4714,7 +4714,7 @@ msgstr "Nuovo commento"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2008
 msgid "New contract accepted"
-msgstr ""
+msgstr "Nuovo contratto accettato"
 
 #: src/components/_political/partyMotion/PartyMotionFormModal.tsx:157
 msgid "New ethics configuration"
@@ -4736,11 +4736,11 @@ msgstr "Nuova posizione"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionList.tsx:121
 msgid "New Mercenary Auction"
-msgstr ""
+msgstr "Nuova asta mercenaria"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2029
 msgid "New message"
-msgstr ""
+msgstr "Nuovo messaggio"
 
 #: src/components/_military/mu/MuFormModal.tsx:89
 msgid "New military unit"
@@ -4806,7 +4806,7 @@ msgstr "Il prossimo sarà carro armato"
 
 #: src/components/_military/mu/MuLevel.tsx:97
 msgid "Next reward"
-msgstr ""
+msgstr "Prossima ricompensa"
 
 #: src/components/_military/battle/BattleSystem.tsx:604
 msgid "Next tick"
@@ -4850,7 +4850,7 @@ msgstr "Nessun token API ancora. Creane uno per iniziare."
 
 #: src/components/_user/auth/ConnectFromModal.tsx:140
 msgid "No authorization code provided."
-msgstr ""
+msgstr "Nessun codice di autorizzazione fornito."
 
 #: src/components/_military/battle/EndedBattlesList.tsx:115
 msgid "No battles yet"
@@ -4858,7 +4858,7 @@ msgstr "Nessuna battaglia ancora"
 
 #: src/components/_military/mercenaryContract/AuctionBidsModal.tsx:28
 msgid "No bids yet"
-msgstr ""
+msgstr "Nessuna offerta ancora"
 
 #: src/pages/country/[countryId]/citizens.tsx:39
 msgid "No citizens"
@@ -4890,15 +4890,15 @@ msgstr "Nessuna legge ancora"
 
 #: src/components/_military/mu/MuMemberList.tsx:180
 msgid "No members in this military unit."
-msgstr ""
+msgstr "Nessun membro in questa unità militare."
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionList.tsx:144
 msgid "No mercenary auctions"
-msgstr ""
+msgstr "Nessuna asta mercenaria"
 
 #: src/components/_military/mercenaryContract/MercenaryContractList.tsx:96
 msgid "No mercenary contracts"
-msgstr ""
+msgstr "Nessun contratto mercenario"
 
 #: src/components/_military/mu/MuList.tsx:93
 msgid "No military units found"
@@ -4922,11 +4922,11 @@ msgstr "Nessuna offerta trovata"
 
 #: src/components/_political/government/Government.tsx:205
 msgid "No one nominated yet"
-msgstr ""
+msgstr "Nessuno nominato ancora"
 
 #: src/components/_military/battle/BattleSideOrdersModal.tsx:109
 msgid "No orders"
-msgstr ""
+msgstr "Nessun ordine"
 
 #: src/components/_political/party/PartyList.tsx:95
 msgid "No parties found"
@@ -4997,11 +4997,11 @@ msgstr "Non impressionante, ma neanche vergognoso"
 #: src/pages/notifications.tsx:38
 #: src/pages/user/[userId]/settings.tsx:79
 msgid "Notification preferences"
-msgstr ""
+msgstr "Preferenze notifiche"
 
 #: src/pages/notifications.tsx:30
 msgid "Notifications"
-msgstr ""
+msgstr "Notifiche"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:61
 msgid "Now we're talking!"
@@ -5017,7 +5017,7 @@ msgstr "Regione occupata"
 
 #: src/components/_political/government/Government.tsx:179
 msgid "of"
-msgstr ""
+msgstr "di"
 
 #: src/utils/translations.tsx:87
 msgid "Oil"
@@ -5037,11 +5037,11 @@ msgstr "Omg, troppo OP"
 
 #: src/components/_military/mercenaryContract/MercenaryReputationTooltip.tsx:20
 msgid "On contract completion: +1 rep per <0/> paid out."
-msgstr ""
+msgstr "Al completamento del contratto: +1 rep per ogni <0/> pagato."
 
 #: src/components/_military/mercenaryContract/MercenaryReputationTooltip.tsx:26
 msgid "On contract failure: -1 rep per <0/> in budget, and -1 rep per <1/> short of completing the contract."
-msgstr ""
+msgstr "Al fallimento del contratto: -1 rep per ogni <0/> nel budget, e -1 rep per ogni <1/> mancante al completamento del contratto."
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:70
 msgid "One step away from legendary..."
@@ -5111,7 +5111,7 @@ msgstr "Apri la chat"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:216
 msgid "Open to all"
-msgstr ""
+msgstr "Aperto a tutti"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:98
 msgid "Open your case!"
@@ -5135,7 +5135,7 @@ msgstr "Ordini"
 
 #: src/components/_military/battle/BattleOrderActionsDropdown.tsx:142
 msgid "Orders & actions"
-msgstr ""
+msgstr "Ordini e azioni"
 
 #: src/pages/market/index.tsx:122
 msgid "Orders cancelled"
@@ -5153,11 +5153,11 @@ msgstr "Esito"
 
 #: src/components/_military/damageRanking/DamageRankingSides.tsx:157
 msgid "Overall"
-msgstr ""
+msgstr "Generale"
 
 #: src/components/_user/user/SkillValue.tsx:152
 msgid "Overflow:"
-msgstr ""
+msgstr "Overflow:"
 
 #: src/components/_military/war/WarHeader.tsx:77
 msgid "Overview"
@@ -5174,7 +5174,7 @@ msgstr "Unità militari possedute"
 
 #: src/components/_military/mu/MuMemberList.tsx:321
 msgid "Owner"
-msgstr ""
+msgstr "Proprietario"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1125
 msgid "Ownership of <0/> has been transferred from <1/> to <2/>"
@@ -5182,11 +5182,11 @@ msgstr "La proprietà di <0/> è stata trasferita da <1/> a <2/>"
 
 #: src/components/_military/mu/MuMemberList.tsx:120
 msgid "Ownership transferred successfully"
-msgstr ""
+msgstr "Proprietà trasferita con successo"
 
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:55
 msgid "Pacification Center"
-msgstr ""
+msgstr "Centro di pacificazione"
 
 #: src/components/_political/party/party.frontConfig.tsx:64
 #: src/components/_political/party/party.frontConfig.tsx:77
@@ -5251,15 +5251,15 @@ msgstr "Partito creato"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1921
 msgid "Party election candidacy open"
-msgstr ""
+msgstr "Candidatura elezione di partito aperta"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1927
 msgid "Party election ended"
-msgstr ""
+msgstr "Elezione di partito terminata"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1924
 msgid "Party election vote open"
-msgstr ""
+msgstr "Votazione elezione di partito aperta"
 
 #: src/components/_political/election/election.frontConfig.tsx:33
 msgid "Party Leader election"
@@ -5279,15 +5279,15 @@ msgstr "Le votazioni per l'elezione del leader del partito sono ora aperte in <0
 
 #: src/components/_user/notification/notification.frontConfig.tsx:232
 msgid "Party Primary election candidacy is now open in <0/>"
-msgstr ""
+msgstr "Le candidature per le elezioni primarie del partito sono ora aperte in <0/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:282
 msgid "Party Primary election has ended in <0/>. Check the results!"
-msgstr ""
+msgstr "Le elezioni primarie del partito sono terminate in <0/>. Controlla i risultati!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:257
 msgid "Party Primary election voting is now open in <0/>"
-msgstr ""
+msgstr "Le votazioni per le elezioni primarie del partito sono ora aperte in <0/>"
 
 #: src/components/_political/election/CandidateFormModal.tsx:71
 msgid "Paste a link to your campaign article, or leave empty."
@@ -5299,7 +5299,7 @@ msgstr "Pagamento riuscito! Grazie per supportare il gioco <3"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:179
 msgid "Payout"
-msgstr ""
+msgstr "Pagamento"
 
 #: src/components/_political/event/EventList.tsx:63
 msgid "Peace made"
@@ -5307,7 +5307,7 @@ msgstr "Pace fatta"
 
 #: src/utils/translations.tsx:259
 msgid "Pending"
-msgstr ""
+msgstr "In attesa"
 
 #: src/components/_user/worker/WorkerEditFormModal.tsx:165
 msgid "Pending wage reduction"
@@ -5315,7 +5315,7 @@ msgstr "Riduzione salariale in sospeso"
 
 #: src/components/_political/event/event.frontConfig.tsx:342
 msgid "People are angry, an auto revolt has started in <0/>"
-msgstr ""
+msgstr "La gente è arrabbiata, una rivolta automatica è iniziata in <0/>"
 
 #: src/utils/translations.tsx:86
 msgid "Petroleum"
@@ -5327,19 +5327,19 @@ msgstr "Sottufficiale"
 
 #: src/components/_user/modals/PhoneVerificationModal.tsx:60
 msgid "Phone number verified!"
-msgstr ""
+msgstr "Numero di telefono verificato!"
 
 #: src/components/_user/modals/PhoneVerificationModal.tsx:99
 msgid "Phone Verification"
-msgstr ""
+msgstr "Verifica telefonica"
 
 #: src/components/_user/user/UserDropdown.tsx:187
 msgid "Phone verification requested"
-msgstr ""
+msgstr "Verifica telefonica richiesta"
 
 #: src/components/_user/modals/PhoneVerificationModal.tsx:105
 msgid "Phone verification required"
-msgstr ""
+msgstr "Verifica telefonica richiesta"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:137
 msgid "Pick a fight!"
@@ -5378,11 +5378,11 @@ msgstr "Mozioni politiche"
 
 #: src/components/_user/notification/notificationPrefs.categories.ts:156
 msgid "Politics & Government"
-msgstr ""
+msgstr "Politica e governo"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:199
 msgid "Popular Article"
-msgstr ""
+msgstr "Articolo popolare"
 
 #: src/components/_user/user/skills.frontConfig.tsx:130
 #: src/components/_user/user/skills.frontConfig.tsx:131
@@ -5395,7 +5395,7 @@ msgstr "Premium"
 
 #: src/components/_user/notification/notificationPrefs.categories.ts:153
 msgid "Premium & Gifts"
-msgstr ""
+msgstr "Premium e regali"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1852
 msgid "Premium activated"
@@ -5469,7 +5469,7 @@ msgstr "Privato"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:205
 msgid "Pro Only"
-msgstr ""
+msgstr "Solo Pro"
 
 #: src/components/_user/user/skills.frontConfig.tsx:50
 msgid "Probability of landing a critical hit"
@@ -5523,11 +5523,11 @@ msgstr "Produzione piena"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:210
 msgid "Professionals Only"
-msgstr ""
+msgstr "Solo Professionisti"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:219
 msgid "Professionals only (5+ rep)"
-msgstr ""
+msgstr "Solo professionisti (5+ rep)"
 
 #: src/components/_user/user/MyAvatar.tsx:29
 msgid "Profile"
@@ -5536,7 +5536,7 @@ msgstr "Profilo"
 #: src/components/_military/mu/MuMemberList.tsx:146
 #: src/components/_military/mu/MuMemberList.tsx:434
 msgid "Promote to Commander"
-msgstr ""
+msgstr "Promuovi a Comandante"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1996
 msgid "Promoted to Commander"
@@ -5554,7 +5554,7 @@ msgstr "Proponi alleanza"
 
 #: src/components/_political/law/law.frontConfig.tsx:260
 msgid "Propose alliance to <0/>"
-msgstr ""
+msgstr "Proponi alleanza a <0/>"
 
 #. placeholder {0}: gameConfig?.battle.allianceDamagesBonusPercent
 #: src/components/_political/law/law.frontConfig.tsx:269
@@ -5611,7 +5611,7 @@ msgstr "Proposte"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:164
 msgid "Purple Staff"
-msgstr ""
+msgstr "Bastone Viola"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:35
 msgid "Put yourself to work!"
@@ -5628,11 +5628,11 @@ msgstr "Smantella rapidamente gli oggetti"
 
 #: src/components/_military/battle/BattleHeader.tsx:299
 msgid "Ranking"
-msgstr ""
+msgstr "Classifica"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1943
 msgid "Ranking reward"
-msgstr ""
+msgstr "Ricompensa classifica"
 
 #: src/components/_layout/MoreButtonNav.tsx:120
 #: src/pages/country/[countryId]/index.tsx:171
@@ -5646,11 +5646,11 @@ msgstr "Gradi"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:168
 msgid "Rate"
-msgstr ""
+msgstr "Tasso"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:141
 msgid "Rate per 1K damage"
-msgstr ""
+msgstr "Tasso per 1K di danno"
 
 #: src/components/_economy/workOffer/EstimatedCompanyBenefit.tsx:128
 msgid "Raw materials:"
@@ -5736,7 +5736,7 @@ msgstr "Recluta"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:167
 msgid "Red Staff"
-msgstr ""
+msgstr "Bastone Rosso"
 
 #: src/components/_user/user/skills.frontConfig.tsx:70
 msgid "Reduces health lost when fighting in battles"
@@ -5781,7 +5781,7 @@ msgstr "Rigenera tra..."
 #: src/utils/translations.tsx:61
 #: src/utils/translations.tsx:74
 msgid "Regens <0>{0}</0> when consumed"
-msgstr ""
+msgstr "Rigenera <0>{0}</0> quando consumato"
 
 #: src/components/_political/party/PartyFormModal.tsx:109
 msgid "Region"
@@ -5882,7 +5882,7 @@ msgstr "Rimuovi avatar"
 
 #: src/components/_military/battle/BattleOrderActionsDropdown.tsx:116
 msgid "Remove bounty"
-msgstr ""
+msgstr "Rimuovi taglia"
 
 #: src/components/_political/partyMotion/partyMotion.frontConfig.tsx:31
 msgid "Remove council member"
@@ -5917,11 +5917,11 @@ msgstr "Rinomina azienda"
 
 #: src/components/_political/government/Government.tsx:219
 msgid "Replace"
-msgstr ""
+msgstr "Sostituisci"
 
 #: src/components/_political/government/Government.tsx:257
 msgid "Replace {title}"
-msgstr ""
+msgstr "Sostituisci {title}"
 
 #: src/components/_political/partyMotion/partyMotion.frontConfig.tsx:80
 msgid "Replace all party ethics with a new configuration"
@@ -5929,11 +5929,11 @@ msgstr "Sostituisci tutte le etiche del partito con una nuova configurazione"
 
 #: src/components/_political/government/NominateForm.tsx:57
 msgid "Replacing a member"
-msgstr ""
+msgstr "Sostituzione di un membro"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItem.tsx:66
 msgid "Report"
-msgstr ""
+msgstr "Segnala"
 
 #: src/components/_user/user/UserDropdown.tsx:268
 msgid "Report user"
@@ -5946,11 +5946,11 @@ msgstr "Repubblicano"
 
 #: src/components/_military/mercenaryContract/MercenaryReputationTooltip.tsx:34
 msgid "Reputation decays 20% toward 0 every week (minimum 1 point)."
-msgstr ""
+msgstr "La reputazione decade del 20% verso 0 ogni settimana (minimo 1 punto)."
 
 #: src/components/_user/user/UserDropdown.tsx:335
 msgid "Request Phone Verification"
-msgstr ""
+msgstr "Richiedi verifica telefonica"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:197
 msgid "Requests:"
@@ -5970,7 +5970,7 @@ msgstr "Reimposta CAPTCHA"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:129
 msgid "Reset Survivor"
-msgstr ""
+msgstr "Sopravvissuto al reset"
 
 #: src/pages/user/[userId]/settings.tsx:74
 msgid "Reset tutorials"
@@ -6039,7 +6039,7 @@ msgstr "Rivoluzione iniziata!"
 
 #: src/components/_user/badgeCollection/Badge.tsx:53
 msgid "Reward"
-msgstr ""
+msgstr "Ricompensa"
 
 #: src/utils/translations.tsx:24
 msgid "Rifle"
@@ -6051,30 +6051,30 @@ msgstr "Diritti"
 
 #: src/components/_military/mercenaryContract/AdminDeleteContractModal.tsx:51
 msgid "Rollback money (take back all payments from MU/users and refund full pool to country)"
-msgstr ""
+msgstr "Rimborsa denaro (riprendi tutti i pagamenti da UM/utenti e rimborsa il pool completo al paese)"
 
 #: src/utils/translations.tsx:255
 msgid "Rolled back by admin"
-msgstr ""
+msgstr "Annullato dall'amministratore"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:240
 msgid "Rolled back by Admin"
-msgstr ""
+msgstr "Annullato dall'Amministratore"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:200
 msgid "Round"
-msgstr ""
+msgstr "Round"
 
 #. placeholder {0}: auction.roundNumber
 #. placeholder {0}: contract.roundNumber
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:214
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:132
 msgid "Round {0}"
-msgstr ""
+msgstr "Round {0}"
 
 #: src/components/_military/damageRanking/BattleLoot.tsx:90
 msgid "Round {roundNumber} loot pool"
-msgstr ""
+msgstr "Pool bottino round {roundNumber}"
 
 #. placeholder {0}: i + 1
 #: src/components/_military/damageRanking/DamageRankingSides.tsx:76
@@ -6097,15 +6097,15 @@ msgstr "Round terminato"
 #: src/components/_military/battle/BattleSystem.tsx:458
 #: src/components/_military/battle/BattleSystem.tsx:495
 msgid "Round ETA"
-msgstr ""
+msgstr "ETA round"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:79
 msgid "Round Hero"
-msgstr ""
+msgstr "Eroe del round"
 
 #: src/components/_military/damageRanking/BattleLoot.tsx:60
 msgid "Round loot"
-msgstr ""
+msgstr "Bottino del round"
 
 #: src/components/_military/battle/BattleTimeline.tsx:78
 msgid "Rounds timeline"
@@ -6276,7 +6276,7 @@ msgstr "Invia un messaggio per completare il tutorial. Benvenuto nella community
 
 #: src/components/_user/modals/PhoneVerificationModal.tsx:135
 msgid "Send Code"
-msgstr ""
+msgstr "Invia codice"
 
 #: src/components/_other/shop/SkinPackModal.tsx:300
 msgid "Send Gift"
@@ -6312,7 +6312,7 @@ msgstr "Imposta un articolo di benvenuto per il tuo paese<0/>"
 
 #: src/components/_military/battle/BattleOrderActionsDropdown.tsx:129
 msgid "Set bounty"
-msgstr ""
+msgstr "Imposta taglia"
 
 #: src/components/_political/law/law.frontConfig.tsx:481
 #: src/components/_political/law/lawNames.tsx:34
@@ -6322,7 +6322,7 @@ msgstr "Imposta colore del paese"
 #. placeholder {0}: law.data.scheme
 #: src/components/_political/law/law.frontConfig.tsx:473
 msgid "Set country color to <0>{0}</0> "
-msgstr ""
+msgstr "Imposta il colore del paese su <0>{0}</0> "
 
 #: src/components/_political/partyMotion/partyMotion.frontConfig.tsx:88
 msgid "Set new party ethics configuration:"
@@ -6330,7 +6330,7 @@ msgstr "Imposta una nuova configurazione delle etiche del partito:"
 
 #: src/components/_military/battle/BattleOrderActionsDropdown.tsx:97
 msgid "Set order"
-msgstr ""
+msgstr "Imposta ordine"
 
 #: src/components/_political/partyMotion/partyMotion.frontConfig.tsx:79
 msgid "Set party ethics"
@@ -6385,7 +6385,7 @@ msgstr "Negozio"
 #. placeholder {0}: auction.bids.length
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:270
 msgid "Show all {0} bids"
-msgstr ""
+msgstr "Mostra tutte le {0} offerte"
 
 #: src/components/_military/damageRanking/DamageRankingList.tsx:205
 #: src/components/_social/ArticleTags.tsx:265
@@ -6398,27 +6398,27 @@ msgstr "Mostra altro"
 #. placeholder {0}: items.length - modalLimit
 #: src/components/_economy/inventory/MultiItems.tsx:88
 msgid "Show more ({0} remaining)"
-msgstr ""
+msgstr "Mostra altro ({0} rimanenti)"
 
 #: src/components/_social/ArticleList.tsx:140
 msgid "Show only articles with positive score (score >= -5)"
-msgstr ""
+msgstr "Mostra solo articoli con punteggio positivo (punteggio >= -5)"
 
 #: src/components/_military/mu/MuMemberList.tsx:199
 msgid "Showing monthly"
-msgstr ""
+msgstr "Visualizzazione mensile"
 
 #: src/components/_military/mu/MuMemberList.tsx:198
 msgid "Showing total"
-msgstr ""
+msgstr "Visualizzazione totale"
 
 #: src/components/_military/mu/MuMemberList.tsx:200
 msgid "Showing weekly"
-msgstr ""
+msgstr "Visualizzazione settimanale"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:192
 msgid "Side"
-msgstr ""
+msgstr "Fazione"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:19
 msgid "Skill issue?"
@@ -6426,7 +6426,7 @@ msgstr "Problema di skill?"
 
 #: src/components/_user/user/SkillValue.tsx:45
 msgid "Skill upgrade:"
-msgstr ""
+msgstr "Potenziamento abilità:"
 
 #: src/components/_user/user/MyAvatar.tsx:41
 #: src/components/_user/user/UserHeader.tsx:172
@@ -6464,7 +6464,7 @@ msgstr "Pacchetti skin"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2047
 msgid "Skin Reward"
-msgstr ""
+msgstr "Ricompensa skin"
 
 #: src/components/_other/shop/ShopHeader.tsx:22
 #: src/pages/user/[userId]/index.tsx:93
@@ -6485,7 +6485,7 @@ msgstr "Cecchino"
 
 #: src/components/_user/notification/notificationPrefs.categories.ts:155
 msgid "Social & Messages"
-msgstr ""
+msgstr "Social e messaggi"
 
 #: src/components/_economy/company/CompanyList.tsx:79
 msgid "Some of your companies are disabled."
@@ -6513,7 +6513,7 @@ msgstr "Oggetto di specializzazione"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:191
 msgid "Spellcaster Gloves"
-msgstr ""
+msgstr "Guanti dell'Incantatore"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:74
 msgid "Spend your <0>Energy</0> working here to earn <1>Money</1>. Keep clicking to work more!"
@@ -6574,7 +6574,7 @@ msgstr "Iniziato <0/>"
 
 #: src/components/_military/battle/BattleHeader.tsx:195
 msgid "Started<0/><1/>"
-msgstr ""
+msgstr "Iniziato<0/><1/>"
 
 #: src/components/_user/mission/MissionsList.tsx:215
 msgid "Starting"
@@ -6636,7 +6636,7 @@ msgstr "Risorse strategiche"
 
 #: src/components/_political/event/event.frontConfig.tsx:356
 msgid "Strategic resources have been reshuffled across the whole map."
-msgstr ""
+msgstr "Le risorse strategiche sono state ridistribuite su tutta la mappa."
 
 #: src/components/_social/ArticleList.tsx:189
 msgid "Subscribed"
@@ -6644,7 +6644,7 @@ msgstr "Iscritto"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:136
 msgid "Subscribed and supported the game <3"
-msgstr ""
+msgstr "Abbonato e ha supportato il gioco <3"
 
 #: src/components/_user/user/UserRankingsPanel.tsx:56
 msgid "Subscribers"
@@ -6652,11 +6652,11 @@ msgstr "Iscritti"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:147
 msgid "Successfully logged in!"
-msgstr ""
+msgstr "Accesso effettuato con successo!"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:159
 msgid "Sugar Daddy"
-msgstr ""
+msgstr "Sugar Daddy"
 
 #: src/components/_user/premium/PremiumActions.tsx:57
 msgid "Support the game"
@@ -6685,7 +6685,7 @@ msgstr "Funzione supporter"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:151
 msgid "Supporter Gift"
-msgstr ""
+msgstr "Regalo sostenitore"
 
 #: src/components/_user/user/UserRankingsPanel.tsx:68
 msgid "Supporter gifts"
@@ -6756,7 +6756,7 @@ msgstr "Tasse"
 #: src/components/_military/mercenaryContract/MercenaryAuctionList.tsx:138
 #: src/components/_military/mercenaryContract/MercenaryContractList.tsx:89
 msgid "Terminated"
-msgstr ""
+msgstr "Terminato"
 
 #: src/pages/index.tsx:138
 #: src/pages/rules.tsx:32
@@ -6765,7 +6765,7 @@ msgstr "Termini"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:386
 msgid "Terms of Service"
-msgstr ""
+msgstr "Termini di servizio"
 
 #: src/components/_layout/LayoutMapOptions.tsx:333
 msgid "Texture"
@@ -6789,21 +6789,21 @@ msgstr "Il valore base per il calcolo dei <0>Danni</0>."
 
 #: src/components/_political/event/event.frontConfig.tsx:430
 msgid "The civil war started by <0/> in <1/> has been suppressed"
-msgstr ""
+msgstr "La guerra civile iniziata da <0/> in <1/> è stata soppressa"
 
 #: src/components/_political/event/event.frontConfig.tsx:414
 msgid "The civil war started by <0/> in <1/> has succeeded of <2/> and the government has been overthrown."
-msgstr ""
+msgstr "La guerra civile iniziata da <0/> in <1/> ha avuto successo con <2/> e il governo è stato rovesciato."
 
 #. placeholder {0}: data.refund
 #: src/components/_user/notification/notification.frontConfig.tsx:1587
 msgid "The contract for <0/> has expired. <1>{0}</1> returned to <2/>."
-msgstr ""
+msgstr "Il contratto per <0/> è scaduto. <1>{0}</1> restituito a <2/>."
 
 #. placeholder {0}: data.moneyRolledBack
 #: src/components/_user/notification/notification.frontConfig.tsx:1605
 msgid "The contract has been rolled back. <0>{0}</0> sent back to <1/>."
-msgstr ""
+msgstr "Il contratto è stato annullato. <0>{0}</0> restituito a <1/>."
 
 #: src/components/_user/user/skills.frontConfig.tsx:59
 msgid "The damage factor increase of critical hits over normal hits"
@@ -6825,15 +6825,15 @@ msgstr "L'effetto dei buff consumati è terminato. È iniziata la fase debuff e 
 #: src/components/_military/mercenaryContract/MercenaryContractItem.tsx:85
 #: src/components/_military/mercenaryContract/MercenaryContractModal.tsx:64
 msgid "The MU will receive the acceptance fee back, partial payout for damage done, and a 10% penalty fee of <0>{0}</0>. Are you sure?"
-msgstr ""
+msgstr "L'UM riceverà indietro la commissione di accettazione, un pagamento parziale per i danni inflitti e una penale del 10% di <0>{0}</0>. Sei sicuro?"
 
 #: src/components/_political/event/event.frontConfig.tsx:82
 msgid "The revolution in <0/> has been suppressed. The government remains in power."
-msgstr ""
+msgstr "La rivoluzione in <0/> è stata soppressa. Il governo rimane al potere."
 
 #: src/components/_political/event/event.frontConfig.tsx:68
 msgid "The revolution in <0/> has succeeded! The government has been overthrown."
-msgstr ""
+msgstr "La rivoluzione in <0/> ha avuto successo! Il governo è stato rovesciato."
 
 #: src/pages/region/[regionId]/index.tsx:110
 msgid "The strategic resource will be reshuffled in the following amount of time."
@@ -6849,11 +6849,11 @@ msgstr "L'universo ti deve qualcosa di grosso"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:132
 msgid "This action will submit your MU bid for this contract."
-msgstr ""
+msgstr "Questa azione invierà l'offerta della tua UM per questo contratto."
 
 #: src/components/_military/battle/BattleSystem.tsx:793
 msgid "This bounty is reserved for nationals only."
-msgstr ""
+msgstr "Questa taglia è riservata solo ai nazionali."
 
 #: src/components/_economy/company/CompanyTags.tsx:66
 msgid "This company is disabled because the owner reached the company limit."
@@ -6873,7 +6873,7 @@ msgstr "Ti piace, eh?"
 
 #: src/components/_military/battle/LootSummaryCard.tsx:63
 msgid "This is a summary of the loot you received from this battle. It includes any cases you got as well as the most valuable items from the shared loot pool."
-msgstr ""
+msgstr "Questo è un riepilogo del bottino ricevuto da questa battaglia. Include tutte le casse ottenute e gli oggetti più preziosi del pool bottino condiviso."
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:27
 msgid "This is your company hub. Here you can produce items and build your empire."
@@ -6894,7 +6894,7 @@ msgstr "Questa legge richiede almeno {minActiveCitizen} cittadini attivi (livell
 
 #: src/components/_political/government/Government.tsx:241
 msgid "This member won't be able to be nominated again for {cooldownDays} days."
-msgstr ""
+msgstr "Questo membro non potrà essere nominato di nuovo per {cooldownDays} giorni."
 
 #: src/pages/region/[regionId]/index.tsx:177
 msgid "This region is not linked to it's owner's capital."
@@ -6902,7 +6902,7 @@ msgstr "Questa regione non è collegata alla capitale del proprietario."
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:205
 msgid "This round only"
-msgstr ""
+msgstr "Solo questo round"
 
 #: src/components/_user/user/FamilyGroup.tsx:75
 msgid "This user is not part of any family group"
@@ -6910,7 +6910,7 @@ msgstr "Questo utente non fa parte di nessun gruppo famiglia"
 
 #: src/components/_user/user/UserDropdown.tsx:336
 msgid "This will require the user to verify their mobile phone number."
-msgstr ""
+msgstr "Questo richiederà all'utente di verificare il proprio numero di telefono mobile."
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:132
 msgid "Time to fight for your country! Let's join the action."
@@ -6922,63 +6922,63 @@ msgstr "È ora di produrre!"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:17
 msgid "Tiny Pixel"
-msgstr ""
+msgstr "Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:95
 msgid "Tiny Pixel Ammo"
-msgstr ""
+msgstr "Munizioni Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:107
 msgid "Tiny Pixel Boots"
-msgstr ""
+msgstr "Stivali Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:104
 msgid "Tiny Pixel Chest"
-msgstr ""
+msgstr "Corazza Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:113
 msgid "Tiny Pixel Gloves"
-msgstr ""
+msgstr "Guanti Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:116
 msgid "Tiny Pixel Gun"
-msgstr ""
+msgstr "Pistola Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:98
 msgid "Tiny Pixel Heavy Ammo"
-msgstr ""
+msgstr "Munizioni Pesanti Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:101
 msgid "Tiny Pixel Helmet"
-msgstr ""
+msgstr "Elmo Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:128
 msgid "Tiny Pixel Jet"
-msgstr ""
+msgstr "Jet Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:131
 msgid "Tiny Pixel Light Ammo"
-msgstr ""
+msgstr "Munizioni Leggere Tiny Pixel"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:16
 msgid "Tiny Pixel Pack"
-msgstr ""
+msgstr "Pack Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:110
 msgid "Tiny Pixel Pants"
-msgstr ""
+msgstr "Pantaloni Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:119
 msgid "Tiny Pixel Rifle"
-msgstr ""
+msgstr "Fucile Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:122
 msgid "Tiny Pixel Sniper"
-msgstr ""
+msgstr "Cecchino Tiny Pixel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:125
 msgid "Tiny Pixel Tank"
-msgstr ""
+msgstr "Carro Armato Tiny Pixel"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:301
 msgid "Tip <0>{count}</0> articles"
@@ -6994,15 +6994,15 @@ msgstr "Nome token"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:176
 msgid "Tome of Flames"
-msgstr ""
+msgstr "Tomo delle Fiamme"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:173
 msgid "Tome of Storms"
-msgstr ""
+msgstr "Tomo delle Tempeste"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:170
 msgid "Tome of Tides"
-msgstr ""
+msgstr "Tomo delle Maree"
 
 #: src/components/_military/damageRanking/BattleLoot.tsx:124
 #: src/components/_social/ArticleList.tsx:181
@@ -7019,19 +7019,19 @@ msgstr "Top (1sett)"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:74
 msgid "Top 1 damage in a battle"
-msgstr ""
+msgstr "Danno n.1 in una battaglia"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:80
 msgid "Top 1 damage in a round"
-msgstr ""
+msgstr "Danno n.1 in un round"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:92
 msgid "Top 1 ground points in a battle"
-msgstr ""
+msgstr "Punti a terra n.1 in una battaglia"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:98
 msgid "Top 1 ground points in a round"
-msgstr ""
+msgstr "Punti a terra n.1 in un round"
 
 #: src/components/_economy/workOffer/WageInfoAlert.tsx:84
 msgid "Top 3 offers"
@@ -7055,7 +7055,7 @@ msgstr "Migliori donatori di regali del mese"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:97
 msgid "Top of the hill"
-msgstr ""
+msgstr "In cima alla collina"
 
 #: src/components/_military/battle/BattleSystem.tsx:658
 msgid "total"
@@ -7076,7 +7076,7 @@ msgstr "Totale"
 
 #: src/components/_economy/inventory/case/OpenCaseModal.tsx:470
 msgid "Total cases opened"
-msgstr ""
+msgstr "Totale casse aperte"
 
 #: src/components/_user/user/UserRankingsPanel.tsx:27
 msgid "Total damages"
@@ -7088,13 +7088,13 @@ msgstr "Totale donato:"
 
 #: src/components/_user/badgeCollection/Badge.tsx:57
 msgid "Total reward"
-msgstr ""
+msgstr "Ricompensa totale"
 
 #: src/components/_military/mu/MuMemberList.tsx:361
 #: src/components/_military/mu/MuMemberList.tsx:401
 #: src/components/_user/user/SkillValue.tsx:215
 msgid "Total:"
-msgstr ""
+msgstr "Totale:"
 
 #: src/components/_military/battle/ActiveBattlesList.tsx:75
 #: src/components/_military/battle/ActiveBattlesList.tsx:139
@@ -7116,11 +7116,11 @@ msgstr "Torneo terminato"
 
 #: src/components/_user/user/SkillValue.tsx:116
 msgid "Tournament reward:"
-msgstr ""
+msgstr "Ricompensa torneo:"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1969
 msgid "Tournament round won!"
-msgstr ""
+msgstr "Round del torneo vinto!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1976
 msgid "Tournament Started"
@@ -7141,7 +7141,7 @@ msgstr "Trading"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1896
 msgid "Trading transaction"
-msgstr ""
+msgstr "Transazione commerciale"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:16
 msgid "Trainee"
@@ -7164,7 +7164,7 @@ msgstr "Trasferisci denaro"
 
 #: src/components/_military/mu/MuMemberList.tsx:161
 msgid "Transfer Ownership"
-msgstr ""
+msgstr "Trasferisci proprietà"
 
 #: src/components/_user/worker/WorkerEditFormModal.tsx:199
 msgid "Transfer to company (optional)"
@@ -7172,11 +7172,11 @@ msgstr "Trasferisci all'azienda (opzionale)"
 
 #: src/components/_political/law/law.frontConfig.tsx:344
 msgid "Transfer<0/> to <1/>"
-msgstr ""
+msgstr "Trasferisci <0/> a <1/>"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:209
 msgid "Translator"
-msgstr ""
+msgstr "Traduttore"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:92
 msgid "Trebuchet"
@@ -7383,7 +7383,7 @@ msgstr "utente"
 
 #: src/components/_user/notification/notificationPrefs.categories.ts:152
 msgid "User & Progression"
-msgstr ""
+msgstr "Utente e progressione"
 
 #: src/components/_other/shop/SkinPackModal.tsx:283
 msgid "User already owns all skins"
@@ -7423,7 +7423,7 @@ msgstr "Utenti"
 
 #: src/components/_layout/LayoutUserMenu.tsx:245
 msgid "Users online"
-msgstr ""
+msgstr "Utenti online"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:9
 msgid "UwU"
@@ -7503,7 +7503,7 @@ msgstr "Codice di verifica"
 
 #: src/components/_user/modals/PhoneVerificationModal.tsx:50
 msgid "Verification code sent!"
-msgstr ""
+msgstr "Codice di verifica inviato!"
 
 #: src/components/_user/auth/LoginFormModal.tsx:149
 #: src/components/_user/modals/PhoneVerificationModal.tsx:181
@@ -7525,7 +7525,7 @@ msgstr "Vicepresidente"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItem.tsx:60
 msgid "View details"
-msgstr ""
+msgstr "Visualizza dettagli"
 
 #: src/components/_military/battle/BattleHeader.tsx:126
 msgid "View on map"
@@ -7533,7 +7533,7 @@ msgstr "Vedi sulla mappa"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:103
 msgid "Voter"
-msgstr ""
+msgstr "Votante"
 
 #: src/components/_military/war/WarComparison.tsx:45
 msgid "VS"
@@ -7596,7 +7596,7 @@ msgstr "War Era è 100% free-to-play e non ha <0>pubblicità</0> né <1>pay-to-w
 
 #: src/components/_user/userReports/ReportFormModal.tsx:83
 msgid "Warning"
-msgstr ""
+msgstr "Avviso"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:76
 msgid "Warrant Officer"
@@ -7618,11 +7618,11 @@ msgstr "Arma"
 
 #: src/components/_user/user/SkillValue.tsx:58
 msgid "Weapon:"
-msgstr ""
+msgstr "Arma:"
 
 #: src/components/_user/user/WealthPanel.tsx:63
 msgid "Weapons"
-msgstr ""
+msgstr "Armi"
 
 #: src/components/_military/mu/MuMemberList.tsx:192
 #: src/components/_user/mission/MissionsList.tsx:203
@@ -7644,7 +7644,7 @@ msgstr "Reset missioni settimanali"
 #: src/components/_military/mu/MuMemberList.tsx:349
 #: src/components/_military/mu/MuMemberList.tsx:379
 msgid "Weekly:"
-msgstr ""
+msgstr "Settimanale:"
 
 #: src/components/_user/auth/LoginFormModal.tsx:59
 msgid "Welcome back {username}!"
@@ -7681,11 +7681,11 @@ msgstr "con bonus + fedeltà"
 #: src/components/_military/battle/ActiveBattlesList.tsx:111
 #: src/components/_military/battle/ActiveBattlesList.tsx:174
 msgid "With bounty"
-msgstr ""
+msgstr "Con taglia"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:182
 msgid "Wizard Hat"
-msgstr ""
+msgstr "Cappello del Mago"
 
 #: src/pages/events/index.tsx:139
 msgid "Won by"
@@ -7790,15 +7790,15 @@ msgstr "Sei molto bravo!"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:225
 msgid "You are/were a council member, sharing ideas and feedback to improve the game <3"
-msgstr ""
+msgstr "Sei/eri un membro del consiglio, condividendo idee e feedback per migliorare il gioco <3"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:143
 msgid "You are/were a part of the staff and helped the game to grow <3"
-msgstr ""
+msgstr "Sei/eri parte dello staff e hai aiutato il gioco a crescere <3"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:110
 msgid "You bought a coffee for the dev <3"
-msgstr ""
+msgstr "Hai offerto un caffè allo sviluppatore <3"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:591
 msgid "You bought items."
@@ -7811,7 +7811,7 @@ msgstr "Hai rotto l'RNG"
 #. placeholder {0}: staticGameConfig.referral.levelNeededForBadge
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:172
 msgid "You brought 10 babies to the world (>= lvl {0})"
-msgstr ""
+msgstr "Hai portato 10 nuovi giocatori nel mondo (>= lvl {0})"
 
 #: src/components/_economy/inventory/DismantleModal.tsx:208
 msgid "You can dismantle items from your inventory by selecting an item."
@@ -7835,15 +7835,15 @@ msgstr "Non hai il permesso di visualizzare le richieste."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1473
 msgid "You earned gems from a banner sale!"
-msgstr ""
+msgstr "Hai guadagnato gemme dalla vendita di un banner!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1797
 msgid "You earned gems from a sale of \"{skinTitle}\"!"
-msgstr ""
+msgstr "Hai guadagnato gemme dalla vendita di \"{skinTitle}\"!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1799
 msgid "You earned gems from a skin pack sale!"
-msgstr ""
+msgstr "Hai guadagnato gemme dalla vendita di un pack skin!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:727
 msgid "You feel healthy, the debuff effect no longer affects you."
@@ -7851,7 +7851,7 @@ msgstr "Ti senti in salute, l'effetto del debuff non ti influenza più."
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:153
 msgid "You gifted a supporter plan subscription to someone <3"
-msgstr ""
+msgstr "Hai regalato un abbonamento al piano sostenitore a qualcuno <3"
 
 #: src/pages/country/[countryId]/citizenship.tsx:48
 msgid "You gonna be automatically approved because the country population is below"
@@ -7906,21 +7906,21 @@ msgstr "Devi aspettare {0} giorni prima di poter prendere di nuovo il controllo 
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:124
 msgid "You helped the dev find a bug, ty <3"
-msgstr ""
+msgstr "Hai aiutato lo sviluppatore a trovare un bug, grazie <3"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:218
 msgid "You helped the dev find an exploit, ty <3"
-msgstr ""
+msgstr "Hai aiutato lo sviluppatore a trovare un exploit, grazie <3"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:211
 msgid "You helped translate the game into another language"
-msgstr ""
+msgstr "Hai aiutato a tradurre il gioco in un'altra lingua"
 
 #. placeholder {0}: staticGameConfig.referral.levelNeededForBadge
 #. placeholder {1}: staticGameConfig.referral.lifeTimeBadgeMoneySharePercent
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:34
 msgid "You invited a friend or spammed forum posts. After they reach level {0}, you will get the badge + {1}% of all your referrals' badge rewards"
-msgstr ""
+msgstr "Hai invitato un amico o hai spammato post nel forum. Dopo che raggiungono il livello {0}, otterrai il badge + {1}% di tutte le ricompense badge dei tuoi referral"
 
 #: src/components/_user/worker/WageReductionAlert.tsx:44
 msgid "You left the company."
@@ -7951,7 +7951,7 @@ msgstr "Devi prima equipaggiare un'arma"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:161
 msgid "You paid the dev's bills <3 (top 3 in monthly supporter gifts ranking)"
-msgstr ""
+msgstr "Hai pagato le bollette dello sviluppatore <3 (top 3 nella classifica mensile dei regali sostenitore)"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1027
 msgid "You premium gift from <0/> has expired! Would you consider subscribing and supporting the game? 👉👈"
@@ -7960,7 +7960,7 @@ msgstr "Il tuo regalo premium da <0/> è scaduto! Prenderesti in considerazione 
 #. placeholder {0}: data.rank
 #: src/components/_user/notification/notification.frontConfig.tsx:1232
 msgid "You received a loot item for rank <0>#{0}</0> in <1/>"
-msgstr ""
+msgstr "Hai ricevuto un oggetto bottino per il rango <0>#{0}</0> in <1/>"
 
 #. placeholder {0}: data.muId ? ( <MuName muId={data.muId} /> ) : data.countryId ? ( <CountryName countryId={data.countryId} /> ) : ( 'your' )
 #. placeholder {1}: data.rank && ( <> position{' '} <Typo fw='bold' color='text1'> #{data.rank} </Typo> </> )
@@ -7970,7 +7970,7 @@ msgstr "Hai ricevuto una ricompensa per {0} {1} nel tier <0/> della classifica <
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1817
 msgid "You received the skin \"{skinTitle}\"!"
-msgstr ""
+msgstr "Hai ricevuto la skin \"{skinTitle}\"!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:593
 msgid "You sold items."
@@ -7996,7 +7996,7 @@ msgstr "Hai regalato con successo il pacchetto di skin \"{0}\" a <0/>!"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:130
 msgid "You survived the big reset"
-msgstr ""
+msgstr "Hai sopravvissuto al grande reset"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:20
 msgid "You very lucky"
@@ -8004,7 +8004,7 @@ msgstr "Sei davvero fortunato"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:104
 msgid "You voted in a major election"
-msgstr ""
+msgstr "Hai votato in un'elezione importante"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:536
 msgid "You was fired from the government by <0/>"
@@ -8012,7 +8012,7 @@ msgstr "Sei stato rimosso dal governo da <0/>"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:117
 msgid "You were an alpha tester (user before 20 march 2025)"
-msgstr ""
+msgstr "Eri un alpha tester (utente prima del 20 marzo 2025)"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1912
 #: src/components/_user/notification/notification.frontConfig.tsx:1929
@@ -8021,23 +8021,23 @@ msgstr "Sei stato eletto"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:59
 msgid "You were elected as a congress member of your country"
-msgstr ""
+msgstr "Sei stato eletto membro del congresso del tuo paese"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:52
 msgid "You were elected as president of your country"
-msgstr ""
+msgstr "Sei stato eletto presidente del tuo paese"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:46
 msgid "You were here at the beginning of War Era"
-msgstr ""
+msgstr "Eri qui all'inizio dell'Era della Guerra"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:236
 msgid "You were nominated as a government member of a country"
-msgstr ""
+msgstr "Sei stato nominato membro del governo di un paese"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:67
 msgid "You were nominated as vice president of your country"
-msgstr ""
+msgstr "Sei stato nominato vicepresidente del tuo paese"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:21
 msgid "You were so close"
@@ -8050,19 +8050,19 @@ msgstr "Guadagni denaro dal badge + {0}% del reddito da badge di tutti i tuoi re
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:182
 msgid "You won a country tournament"
-msgstr ""
+msgstr "Hai vinto un torneo nazionale"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:194
 msgid "You won a giveaway"
-msgstr ""
+msgstr "Hai vinto un giveaway"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:188
 msgid "You won a MU tournament"
-msgstr ""
+msgstr "Hai vinto un torneo UM"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:86
 msgid "You worked 100 times"
-msgstr ""
+msgstr "Hai lavorato 100 volte"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:220
 msgid "You're all set!"
@@ -8119,7 +8119,7 @@ msgstr "La tua richiesta a <0/> è stata rifiutata"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:201
 msgid "Your article reached 2% of the active population in score (min 10)"
-msgstr ""
+msgstr "Il tuo articolo ha raggiunto il 2% della popolazione attiva in punteggio (min 10)"
 
 #. placeholder {0}: data.bannerTitle
 #: src/components/_user/notification/notification.frontConfig.tsx:1486
@@ -8128,7 +8128,7 @@ msgstr "Il tuo banner \"{0}\" è stato accettato ed è ora disponibile nel negoz
 
 #: src/components/_user/notification/notification.frontConfig.tsx:696
 msgid "Your buff(s) will expire in less than 1 hour. The debuff phase will begin soon."
-msgstr ""
+msgstr "I tuoi buff scadranno in meno di 1 ora. La fase di debuff inizierà presto."
 
 #: src/pages/country/[countryId]/index.tsx:146
 msgid "Your citizenship is going to change"
@@ -8193,7 +8193,7 @@ msgstr "Il tuo inventario contiene tutti i tuoi oggetti. Vediamo cosa hai!"
 #: src/components/_military/battle/LootSummaryCard.tsx:62
 #: src/components/_military/battle/LootSummaryCard.tsx:66
 msgid "Your loot"
-msgstr ""
+msgstr "Il tuo bottino"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:48
 msgid "Your luck is just warming up, don't quit"
@@ -8209,7 +8209,7 @@ msgstr "Nome della tua unità militare"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:223
 msgid "Your MU must have enough money to cover the acceptance fee to bid. Payment is only deducted if you win, and refunded on contract completion."
-msgstr ""
+msgstr "La tua UM deve avere abbastanza denaro per coprire la commissione di accettazione per fare un'offerta. Il pagamento viene detratto solo se vinci e rimborsato al completamento del contratto."
 
 #: src/components/_economy/market/MarketHeader.tsx:14
 msgid "Your offers"


### PR DESCRIPTION
Completed the French (fr) localization by filling in 28 previously missing translation strings.

What was missing: Strings were mostly concentrated in political/law actions, system messages, and mercenary contract UI — likely added in a recent feature batch that wasn't yet translated.

Strings covered:

Law actions: Accept/Break/Propose alliance, Define as enemy, Impeach, Liberate, Finance resistance, Buy region, Change tax, Transfer, Set country color
System messages: <0/> proposed a new law, <0/> dropped from, <0/> ended, <0/> started vote, <0/> wants peace, Candidacy is open
Mercenary UI: New Mercenary Auction, Mercenary earnings, Bounty, Expired: battle/round/no bids, Are you sure you want to place this bid?, This action will submit your MU bid
Misc: Hamster Tank (skin name)

Result: French is now at 100% completion (1934/1934 strings translated).