### PR TITLE
Spanish Localization Update

### DIFF
--- a/es/messages.po
+++ b/es/messages.po
@@ -4,7 +4,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-11-17 01:11+0200\n"
 "PO-Revision-Date: \n"
-"Last-Translator: Milanesa_Sagrada <fchavez.estudio@gmail.com>\n"
+"Last-Translator: Aariz <emgg36@gmail.com>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -31,7 +31,7 @@ msgstr " - Esquemas de fusión de equipo *"
 
 #: src/components/_common/GameRules.tsx:117
 msgid " - Low-wage labor (lower than 0.8x and above 1.2x the normal salary)"
-msgstr " - Trabajo de bajos salarios (inferior a 0,8x y superior a 1,2x del salario normal)"
+msgstr " - Mano de obra mal remunerada (por debajo de 0.8x y por encima de 1.2x del salario normal)"
 
 #. placeholder {0}: user.data.mute.reason
 #: src/components/_user/user/UserHeader.tsx:422
@@ -64,16 +64,16 @@ msgstr "- Defender esta región tendrá una penalización de <0>{0}</0>."
 msgid "- Development income is reduced by 50%:<0>{0}</0>."
 msgstr "- Los ingresos de desarrollo se reducen en un 50%:<0>{0}</0>."
 
-#: src/components/_political/alliance/AllianceMemberRow.tsx:71
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:236
-msgid "(average member development)"
-msgstr ""
+#: src/components/_political/alliance/AllianceMemberRow.tsx:70
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:231
+msgid "(alliance average development)"
+msgstr "(desarrollo promedio de la alianza)"
 
-#: src/components/_political/alliance/AllianceMemberRow.tsx:66
+#: src/components/_political/alliance/AllianceMemberRow.tsx:65
 msgid "(member average development)"
 msgstr "(desarrollo promedio de los miembros)"
 
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:226
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:225
 msgid "(own development)"
 msgstr "(desarrollo propio)"
 
@@ -197,7 +197,7 @@ msgstr "<0/> a <1>{0}</1> de salario.{1}"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:54
 msgid "<0/> banned <1/> from the conversation"
-msgstr "<0/> expulsado <1/> de la conversación"
+msgstr "<0/> expulsó a <1/> de la conversación"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1854
 msgid "<0/> bought your {assetLabel} as a gift for <1/>!"
@@ -218,12 +218,12 @@ msgid "<0/> bought your banner{0}!"
 msgstr "<0/> compró tu banner{0}!"
 
 #. placeholder {0}: law.data.amount ?? 0
-#: src/components/_political/law/law.frontConfig.tsx:443
+#: src/components/_political/law/law.frontConfig.tsx:444
 msgid "<0/> buys <1/> for <2>{0}</2>"
 msgstr "<0/> compra <1/> por <2>{0}</2>"
 
 #. placeholder {0}: law.data.amount ?? 0
-#: src/components/_political/law/law.frontConfig.tsx:454
+#: src/components/_political/law/law.frontConfig.tsx:455
 msgid "<0/> buys your region <1/> for <2>{0}</2>"
 msgstr "<0/> compra tu región <1/> por <2>{0}</2>"
 
@@ -317,7 +317,7 @@ msgstr "<0/> ha sido elegido/a presidente de <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:379
 msgid "<0/> has been excluded from the alliance <1/>"
-msgstr "<0/> ha sido excluido de la alianza <1/>"
+msgstr "<0/> ha sido expulsado de la alianza <1/>"
 
 #. placeholder {0}: data.amount
 #: src/components/_political/event/event.frontConfig.tsx:216
@@ -330,7 +330,7 @@ msgstr "<0/> ha roto su alianza con <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:407
 msgid "<0/> has broken their defensive pact with <1/>"
-msgstr "<0/> ha roto su pacto defensivo con <1/>"
+msgstr "<0/> ha roto su pacto de defensa con <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:103
 msgid "<0/> has conquered <1/> against <2/>"
@@ -352,7 +352,7 @@ msgstr "<0/> ha financiado la resistencia en <1/>"
 msgid "<0/> has formed an alliance with <1/>"
 msgstr "<0/> ha formado una alianza con <1/>"
 
-#: src/components/_political/law/law.frontConfig.tsx:392
+#: src/components/_political/law/law.frontConfig.tsx:393
 msgid "<0/> has invited your country to join."
 msgstr "<0/> ha invitado a tu país a unirse."
 
@@ -449,7 +449,7 @@ msgstr "A <0/> le gustó tu mensaje <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:820
 msgid "<0/> liked your message in <1/><2/>"
-msgstr "A <0/> le gustó tu mensaje en <1/><2/>"
+msgstr "<0/> reaccionó con \"me gusta\" a tu mensaje en <1/><2/>
 
 #: src/components/_political/event/event.frontConfig.tsx:247
 msgid "<0/> made peace with <1/>"
@@ -461,7 +461,7 @@ msgstr "<0/> te mencionó <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1209
 msgid "<0/> mentioned you in <1/><2/>"
-msgstr "<0/> te mencionó <1/><2/>"
+msgstr "<0/> te mencionó en <1/><2/>"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:221
 msgid "<0/> paid fee"
@@ -624,7 +624,7 @@ msgstr "<0>{0}</0> contra el enemigo de <1/>"
 #. placeholder {0}: levelConfig.stats.attackBonus || 0
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:49
 msgid "<0>{0}</0> Attack bonus when attacking from this region.<1/>Citizens get the full bonus, allied countries get half."
-msgstr "<0>{0}</0> Bonificación de ataque al atacar desde esta región.<1/>Los ciudadanos reciben la bonificación completa, los países aliados reciben la mitad."
+msgstr "<0>{0}</0> de bonificación de ataque al atacar desde esta región.<1/>Los ciudadanos reciben toda la bonificación; los países aliados reciben la mitad."
 
 #. placeholder {0}: sideBonus.regionNotLinkedToCapitalMalusPercent
 #: src/components/_military/battle/BattleDamageBonuses.tsx:209
@@ -644,7 +644,7 @@ msgstr "<0>{0}</0> porque <1/> ocupa al menos una de las regiones de <2/>"
 #. placeholder {0}: levelConfig.stats.defenseBonus || 0
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:34
 msgid "<0>{0}</0> Defense bonus when defending this region.<1/>Citizens get the full bonus, allied countries get half. Defensive pact partners don't benefit."
-msgstr "<0>{0}</0> Bonificación de defensa al defender esta región.<1/>Los ciudadanos obtienen la bonificación completa; los países aliados obtienen la mitad. Los socios de un pacto defensivo no se benefician."
+msgstr "<0>{0}</0> de bonificación de defensa al defender esta región.<1/>Los ciudadanos reciben toda la bonificación; los países aliados reciben la mitad. Los aliados mediante pacto de defensa no reciben este beneficio."
 
 #. placeholder {0}: data.acceptanceFeeReturned
 #: src/components/_user/notification/notification.frontConfig.tsx:1614
@@ -671,7 +671,7 @@ msgstr "<0>{0}</0> de <1>Resistencia</1>"
 #. placeholder {0}: sideBonus.defensivePactBonusPercent
 #: src/components/_military/battle/BattleDamageBonuses.tsx:122
 msgid "<0>{0}</0> from a defensive pact with <1/>"
-msgstr "<0>{0}</0> de un pacto defensivo con <1/>"
+msgstr "<0>{0}</0> de un pacto de defensa con <1/>"
 
 #. placeholder {0}: region.ethicDepositBonus
 #: src/components/_economy/company/RecommendedCompanyRegions.tsx:134
@@ -756,7 +756,7 @@ msgstr "Recurso <0>#{key}</0> de cada tipo = <1>{value}</1>"
 
 #: src/components/_political/country/CountryHeader.tsx:207
 msgid "<0>Average development</0> is the average of <1>Core development</1> and <2>Current development</2>."
-msgstr "<0>Desarrollo promedio</0> es el promedio de <1>Desarrollo central</1> y <2>Desarrollo actual</2>."
+msgstr "<0>Desarrollo promedio</0> es el promedio entre el <1>Desarrollo nacional</1> y el <2>Desarrollo actual</2>."
 
 #: src/components/_user/user/UserTooltip.tsx:131
 msgid "<0>Buff</0> ends <1/>"
@@ -764,11 +764,11 @@ msgstr "<0>Buff</0> termina <1/>"
 
 #: src/components/_political/country/CountryHeader.tsx:171
 msgid "<0>Core development</0> is calculated depending on the country's <1>Population</1> and average <2>Level</2>. then distributed equally among the country's <3>Core regions</3>."
-msgstr "<0>Desarrollo central</0> se calcula en función de la <1>Población</1> y el <2>Nivel</2> promedio del país. Luego se distribuye equitativamente entre las <3>Regiones centrales</3> del país."
+msgstr "<0>Desarrollo nacional</0> se calcula en función de la <1>Población</1> y el <2>Nivel</2> promedio del país, y luego se distribuye equitativamente entre las <3>regiones nacionales</3> del país."
 
 #: src/components/_political/country/CountryHeader.tsx:235
 msgid "<0>Current development</0> is the total development of the <1>regions</1> the country currently controls, including conquered territory."
-msgstr "<0>Desarrollo actual</0> es el desarrollo total de las <1>regiones</1> que el país controla actualmente, incluido el territorio conquistado."
+msgstr "<0>Desarrollo actual</0> es el desarrollo total de las <1>regiones</1> que el país controla actualmente, incluyendo los territorios conquistados."
 
 #: src/components/_user/user/UserTooltip.tsx:140
 msgid "<0>Debuff</0> ends <1/>"
@@ -1297,14 +1297,14 @@ msgstr "A favor"
 
 #: src/components/_political/law/law.frontConfig.tsx:287
 msgid "Accept a defensive pact with <0/>"
-msgstr "Aceptar un pacto defensivo con <0/>"
+msgstr "Aceptar un pacto de defensa con <0/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:281
 #: src/components/_political/law/lawNames.tsx:41
 msgid "Accept defensive pact"
-msgstr "Aceptar pacto defensivo"
+msgstr "Aceptar pacto de defensa"
 
-#: src/components/_political/law/law.frontConfig.tsx:439
+#: src/components/_political/law/law.frontConfig.tsx:440
 msgid "Accept or reject a region buy offer"
 msgstr "Aceptar o rechazar una oferta de compra de región"
 
@@ -1372,7 +1372,7 @@ msgstr "Construcción activa"
 msgid "Active War"
 msgstr "Guerra activa"
 
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:259
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:254
 msgid "Active wars"
 msgstr "Guerras activas"
 
@@ -1488,14 +1488,14 @@ msgstr "Todas las transacciones deben ser justas y equilibradas."
 #. placeholder {0}: formatMultiplierDelta( ethicsBonuses.isolationism['-2'].treatyMaintenanceMultiplier, )
 #: src/components/_political/party/party.frontConfig.tsx:161
 msgid "All treaty maintenance costs are increased by <0>{0}</0>."
-msgstr "Todos los costos de mantenimiento de los tratados aumentan en <0>{0}</0>."
+msgstr "Todos los costes de mantenimiento de tratados aumentan en <0>{0}</0>."
 
 #: src/components/_economy/transaction/TransactionList.tsx:70
 msgid "All types"
 msgstr "Todos los tipos"
 
 #: src/components/_layout/map.frontConfig.tsx:32
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:193
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:192
 msgid "Alliance"
 msgstr "Alianza"
 
@@ -1505,7 +1505,7 @@ msgstr "Alianza <0/> (<1/>)"
 
 #: src/components/_political/alliance/AllianceBattleBonus.tsx:92
 msgid "Alliance battle damage bonus"
-msgstr "Bonificación por daño de batalla de la alianza"
+msgstr "Bonificación de daño de batalla de la alianza"
 
 #: src/components/_political/event/EventList.tsx:75
 msgid "Alliance broken"
@@ -1517,7 +1517,7 @@ msgstr "Alianza formada"
 
 #: src/components/_political/allianceLaw/AllianceLawFormModal.tsx:53
 msgid "Alliance law proposed"
-msgstr "Ley propuesta por la Alianza"
+msgstr "Ley de alianza propuesta"
 
 #: src/components/_political/allianceLaw/AllianceLawTypeSelect.tsx:57
 #: src/pages/alliance/[allianceId]/laws.tsx:16
@@ -1589,13 +1589,13 @@ msgstr "Se ha roto una alianza"
 msgid "An alliance has been formed"
 msgstr "Se ha formado una alianza"
 
-#: src/components/_political/law/law.frontConfig.tsx:379
+#: src/components/_political/law/law.frontConfig.tsx:380
 msgid "An alliance has invited your country to join"
-msgstr "Una alianza ha invitado a tu país a unirse."
+msgstr "Una alianza ha invitado a tu país a unirse"
 
 #: src/components/_political/alliance/AllianceBattleBonus.tsx:46
 msgid "An alliance's battle <0>damage</0> bonus depends on its share of the world's total <1>Development</1>."
-msgstr "La bonificación de <0>daño</0> en batalla de una alianza depende de su proporción del <1>Desarrollo</1> total del mundo."
+msgstr "La bonificación de <0>daño</0> de batalla de una alianza depende de su participación en el <1>Desarrollo</1> total mundial."
 
 #: src/components/_user/auth/LoginFormModal.tsx:94
 msgid "An email with the verification code has been sent to {email}"
@@ -1611,7 +1611,7 @@ msgstr "Anuncio"
 
 #: src/components/_political/law/law.frontConfig.tsx:282
 msgid "Another country proposed a defensive pact to yours"
-msgstr "Otro país propuso un pacto defensivo al tuyo."
+msgstr "Otro país propuso un pacto de defensa al tuyo"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:40
 msgid "Anti Terrorist Pack"
@@ -1704,7 +1704,7 @@ msgstr "¿Estás seguro de que quieres eliminar todas las órdenes de venta?"
 
 #: src/pages/country/[countryId]/government.tsx:161
 msgid "Are you sure you want to remove this announcement?"
-msgstr "¿Está seguro de que desea eliminar este anuncio?"
+msgstr "¿Estás seguro de que quieres eliminar este anuncio?"
 
 #: src/components/_user/mission/MissionItem.tsx:115
 msgid "Are you sure you want to reroll this mission? Your current progress will be lost."
@@ -1756,23 +1756,23 @@ msgstr "Artículos de <0/>"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:305
 msgid "AT Ammo"
-msgstr "AT Munición"
+msgstr "Munición AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:296
 msgid "AT Armored Tank"
-msgstr "AT Tanque Blindado"
+msgstr "Tanque Blindado AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:290
 msgid "AT Assault Rifle"
-msgstr "AT Rifle de Asalto"
+msgstr "Rifle de Asalto AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:299
 msgid "AT Combat Helicopter"
-msgstr "AT Helicoptero de Combate"
+msgstr "Helicóptero de Combate AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:308
 msgid "AT Heavy Ammo"
-msgstr "AT Munición pesada"
+msgstr "Munición Pesada AT"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:8
 msgid "At least you tried"
@@ -1780,39 +1780,39 @@ msgstr "Al menos lo intentaste"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:302
 msgid "AT Light Ammo"
-msgstr "AT Munición ligera"
+msgstr "Munición Ligera AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:287
 msgid "AT Pistol"
-msgstr "AT Pistola"
+msgstr "Pistola AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:293
 msgid "AT Sniper Rifle"
-msgstr "AT Rifle Francotirador"
+msgstr "Rifle de Francotirador AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:317
 msgid "AT Tactical Boots"
-msgstr "AT Botas Tácticas"
+msgstr "Botas Tácticas AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:323
 msgid "AT Tactical Gloves"
-msgstr "AT Guantes Tácticos"
+msgstr "Guantes Tácticos AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:311
 msgid "AT Tactical Helmet"
-msgstr "AT Casco Táctico"
+msgstr "Casco Táctico AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:320
 msgid "AT Tactical Pants"
-msgstr "AT Pantalones Táctico"
+msgstr "Pantalones Tácticos AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:284
 msgid "AT Tactical Shield"
-msgstr "AT Escudo Táctico"
+msgstr "Escudo Táctico AT"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:314
 msgid "AT Tactical Vest"
-msgstr "AT Chaleco Táctico"
+msgstr "Chaleco Táctico AT"
 
 #: src/components/_military/battle/BattleSystem.tsx:615
 msgid "At the end of the timer <0>{actualTickPoints}</0> will be assigned to the side with the most damages."
@@ -1950,7 +1950,7 @@ msgstr "Baneos"
 
 #: src/components/_political/law/LawCostExplanation.tsx:38
 msgid "Base cost"
-msgstr "Costo base"
+msgstr "Coste base"
 
 #: src/utils/translations.tsx:203
 msgid "Basic Boots"
@@ -2014,21 +2014,21 @@ msgstr "Órdenes de batalla"
 #. placeholder {0}: formatMultiplierDelta( ethicsBonuses.isolationism['-2'].enemyBattleOrderMultiplier, )
 #: src/components/_political/party/party.frontConfig.tsx:152
 msgid "Battle orders against your sworn enemy cost <0>{0}</0> less."
-msgstr "Las órdenes de batalla contra tu enemigo jurado cuestan <0>{0}</0> menos."
+msgstr "Las órdenes de batalla contra tu enemigo principal cuestan <0>{0}</0> menos."
 
 #. placeholder {0}: formatMultiplierDelta( ethicsBonuses.isolationism[2].pactBattleOrderMultiplier, )
 #: src/components/_political/party/party.frontConfig.tsx:224
 msgid "Battle orders supporting a defensive pact partner cost <0>{0}</0> less."
-msgstr "Las órdenes de batalla que apoyan a un socio de pacto defensivo cuestan <0>{0}</0> menos."
+msgstr "Las órdenes de batalla que apoyan a un socio de pacto de defensa cuestan <0>{0}</0> menos"
 
 #: src/components/_political/party/party.frontConfig.tsx:60
 msgid "Battle orders to defend your core regions and revolts are free."
-msgstr "Las órdenes de batalla para defender tus regiones centrales y las revueltas son gratuitas."
+msgstr "Las órdenes para defender tus regiones nacionales y revueltas son gratuitas."
 
 #. placeholder {0}: formatMultiplierDelta( ethicsBonuses.militarism['-1'].defendCoreRevoltOrderMultiplier, )
 #: src/components/_political/party/party.frontConfig.tsx:75
 msgid "Battle orders to defend your core regions and revolts cost <0>{0}</0> less."
-msgstr "Las órdenes de batalla para defender tus regiones centrales y las revueltas cuestan <0>{0}</0> menos."
+msgstr "Las órdenes para defender tus regiones nacionales y revueltas cuestan <0>{0}</0> menos."
 
 #: src/components/_layout/LayoutMenu.tsx:154
 #: src/components/_military/battle/BattlesHeader.tsx:21
@@ -2086,11 +2086,11 @@ msgstr "Báculo azul"
 
 #: src/components/_layout/LayoutOptions.tsx:149
 msgid "Blur"
-msgstr "Difuminar"
+msgstr "Desenfoque"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:242
 msgid "Bone Club"
-msgstr "Club de Huesos"
+msgstr "Garrote de Hueso"
 
 #: src/components/_military/battle/BattleDamageBonuses.tsx:62
 #: src/components/_political/law/law.frontConfig.tsx:235
@@ -2126,7 +2126,7 @@ msgstr "Pan"
 #: src/components/_political/law/law.frontConfig.tsx:306
 #: src/components/_political/law/lawNames.tsx:42
 msgid "Break defensive pact"
-msgstr "Romper el pacto defensivo"
+msgstr "Romper pacto de defensa"
 
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:119
 msgid "Break room"
@@ -2134,7 +2134,7 @@ msgstr "Sala de descanso"
 
 #: src/components/_political/law/law.frontConfig.tsx:312
 msgid "Break the defensive pact with <0/>"
-msgstr "Rompe el pacto defensivo con <0/>"
+msgstr "Romper el pacto de defensa con <0/>"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:111
 msgid "Brigadier"
@@ -2189,7 +2189,7 @@ msgid "Buy <0/>"
 msgstr "Comprar <0/>"
 
 #. placeholder {0}: law.data.amount ?? 0
-#: src/components/_political/law/law.frontConfig.tsx:471
+#: src/components/_political/law/law.frontConfig.tsx:472
 msgid "Buy <0/> from <1/> for <2>{0}</2>"
 msgstr "Comprar <0/> a <1/> por <2>{0}</2>"
 
@@ -2281,11 +2281,11 @@ msgstr "No puede tener vicepresidente ni ministros."
 
 #: src/components/_political/party/party.frontConfig.tsx:426
 msgid "Cannot have any treaty (sworn enemy, defensive pact or alliance)."
-msgstr "No puede tener ningún tratado (enemigo jurado, pacto defensivo o alianza)."
+msgstr "No puede tener ningún tratado (enemigo principal, pacto de defensa o alianza)."
 
 #: src/components/_political/party/party.frontConfig.tsx:67
 msgid "Cannot have sworn enemies."
-msgstr "No puede tener enemigos jurados."
+msgstr "No puede tener enemigos principales."
 
 #: src/components/_political/party/party.frontConfig.tsx:349
 msgid "Cannot pick a specialization good / no benefit from specialization."
@@ -2325,7 +2325,7 @@ msgstr "Catapulta"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:269
 msgid "Cave Bear Headdress"
-msgstr "Tocado de oso cavernario"
+msgstr "Casco de Oso de las Cavernas"
 
 #: src/components/_user/user/skills.frontConfig.tsx:152
 msgid "Chance per hit to instantly loot:<0/>Each <1>1%</1> gives<2>1%</2> and <3>0.01%</3> to loot cases per hit."
@@ -2351,7 +2351,7 @@ msgstr "Cambiar los impuestos del país"
 #: src/components/_political/alliance/alliance.frontConfig.tsx:19
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:141
 msgid "Change color"
-msgstr "Cambiar el color"
+msgstr "Cambiar color"
 
 #. placeholder {0}: data.newScheme
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:149
@@ -2375,25 +2375,25 @@ msgstr "Cambiar impuesto"
 #. placeholder {0}: data.newScheme
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:158
 msgid "Change the alliance color scheme to <0>{0}</0> immediately on acceptance."
-msgstr "Cambia el esquema de color de la alianza a <0>{0}</0> inmediatamente después de la aceptación."
+msgstr "Cambiar el esquema de colores de la alianza a <0>{0}</0> inmediatamente al ser aceptado"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:142
 msgid "Change the color scheme of the alliance."
-msgstr "Cambia el esquema de colores de la alianza."
+msgstr "Cambiar el esquema de colores de la alianza."
 
-#: src/components/_political/law/law.frontConfig.tsx:545
+#: src/components/_political/law/law.frontConfig.tsx:546
 msgid "Change the country color scheme"
 msgstr "Cambiar la paleta de colores del país"
 
 #. placeholder {0}: law.data.scheme
 #. placeholder {1}: law.data.mapAccent
-#: src/components/_political/law/law.frontConfig.tsx:551
+#: src/components/_political/law/law.frontConfig.tsx:552
 msgid "Change the country color scheme to <0>{0}</0> with a <1>{1}</1> map accent"
 msgstr "Cambiar la paleta de colores del país a <0>{0}</0> con un acento de mapa <1>{1}</1>"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:121
 msgid "Change the name of the alliance."
-msgstr "Cambia el nombre de la alianza."
+msgstr "Cambiar el nombre de la alianza."
 
 #. placeholder {0}: law.data.taxType
 #: src/components/_political/law/law.frontConfig.tsx:76
@@ -2427,7 +2427,7 @@ msgstr "¡Elige tu bando y haz clic para infligir <0>Daño</0>! Sigue golpeando 
 
 #: src/components/_economy/inventory/CraftModal.tsx:358
 msgid "Choosing a specific item costs ×2 steel:"
-msgstr "Elegir un artículo específico cuesta ×2 acero:"
+msgstr "Elegir un objeto específico cuesta ×2 acero:"
 
 #: src/components/_user/user/UserHeader.tsx:282
 msgid "Citizen since <0><1/></0>"
@@ -2514,11 +2514,11 @@ msgstr "Cerrar"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:266
 msgid "Clovis Point"
-msgstr "Punta de Clovis"
+msgstr "Punta Clovis"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:37
 msgid "Cold af"
-msgstr "Super Frio"
+msgstr "Gélido y épico"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:106
 msgid "Colonel"
@@ -2775,11 +2775,11 @@ msgstr "Copia este token ahora. ¡No podrás verlo de nuevo! Úsalo en el encabe
 #: src/components/_political/alliance/AllianceHeader.tsx:90
 #: src/components/_political/government/Government.tsx:206
 msgid "Core development"
-msgstr "Desarrollo central"
+msgstr "Desarrollo Nacional
 
 #: src/pages/country/[countryId]/regions.tsx:28
 msgid "Core regions"
-msgstr "Regiones principales"
+msgstr "Regiones nacionales"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:46
 msgid "Corporal"
@@ -2795,7 +2795,7 @@ msgstr "Miembro del consejo que debe ser destituido"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:41
 msgid "Counter-strike the enemy"
-msgstr "Contraataca al enemigo"
+msgstr "Contraatacar al enemigo"
 
 #: src/components/_layout/LoadingScreenContent.tsx:19
 msgid "countries"
@@ -2819,7 +2819,7 @@ msgstr "Bono de ingresos por desarrollo del país"
 
 #: src/components/_political/event/EventList.tsx:86
 msgid "Country excluded from alliance"
-msgstr "País excluido de la alianza"
+msgstr "País expulsado de la alianza"
 
 #: src/components/_political/event/EventList.tsx:78
 msgid "Country joined alliance"
@@ -2827,11 +2827,11 @@ msgstr "El país se unió a la alianza"
 
 #: src/components/_political/event/EventList.tsx:82
 msgid "Country left alliance"
-msgstr "El país dejó la alianza"
+msgstr "El país abandonó la alianza"
 
 #: src/components/_economy/transaction/TransactionList.tsx:102
 msgid "Country Money Transfer"
-msgstr "Transferencia de dinero del Pais"
+msgstr "Transferencia de dinero entre países"
 
 #: src/components/_military/battle/BattleSideOrdersModal.tsx:62
 msgid "Country Orders"
@@ -2852,7 +2852,7 @@ msgstr "Bono de producción del país"
 
 #: src/components/_political/allianceLaw/AllianceLawFormModal.tsx:141
 msgid "Country to invite"
-msgstr "País para invitar"
+msgstr "País a invitar"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:181
 msgid "Country Tournament Winner"
@@ -2888,7 +2888,7 @@ msgstr "Crear una empresa"
 #. placeholder {1}: law.data.scheme
 #: src/components/_political/law/law.frontConfig.tsx:342
 msgid "Create a new alliance named <0>{0}</0> with <1>{1}</1> color scheme."
-msgstr "Crea una nueva alianza llamada <0>{0}</0> con el esquema de colores <1>{1}</1>."
+msgstr "Crear una nueva alianza llamada <0>{0}</0> con el esquema de colores <1>{1}</1>."
 
 #: src/components/_user/mission/mission.frontConfig.tsx:356
 msgid "Create a new company"
@@ -2957,7 +2957,7 @@ msgstr "Ballesta"
 
 #: src/components/_political/alliance/AllianceBattleBonus.tsx:75
 msgid "Current alliance battle damage bonus → <0/>"
-msgstr "Bonificación de daño de batalla de alianza actual → <0/>"
+msgstr "Bonificación actual de daño de batalla de la alianza → <0/>"
 
 #: src/components/_political/alliance/AllianceHeader.tsx:96
 msgid "Current development"
@@ -2987,7 +2987,7 @@ msgstr "d. Cualquier forma de discriminación, racismo, xenofobia, antisemitismo
 msgid "Daily"
 msgstr "Diarias"
 
-#: src/components/_political/alliance/AllianceMemberRow.tsx:59
+#: src/components/_political/alliance/AllianceMemberRow.tsx:58
 #: src/components/_political/law/LawTypeSelect.tsx:188
 msgid "Daily maintenance"
 msgstr "Mantenimiento diario"
@@ -3147,33 +3147,33 @@ msgstr "Defensor"
 msgid "Defenders"
 msgstr "Defensores"
 
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:334
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:329
 msgid "Defensive pact"
-msgstr "Pacto defensivo"
+msgstr "Pacto de defensa"
 
 #: src/components/_political/event/EventList.tsx:94
 msgid "Defensive pact broken"
-msgstr "Pacto defensivo roto"
+msgstr "Pacto de defensa roto"
 
 #. placeholder {0}: formatMultiplierDelta( ethicsBonuses.isolationism[1].pactMaintenanceMultiplier, )
 #. placeholder {0}: formatMultiplierDelta( ethicsBonuses.isolationism[2].pactMaintenanceMultiplier, )
 #: src/components/_political/party/party.frontConfig.tsx:199
 #: src/components/_political/party/party.frontConfig.tsx:215
 msgid "Defensive pact maintenance costs are reduced by <0>{0}</0>."
-msgstr "Los costos de mantenimiento del pacto defensivo se reducen en <0>{0}</0>."
+msgstr "Los costes de mantenimiento de pactos de defensa se reducen en <0>{0}</0>."
 
 #: src/components/_political/event/EventList.tsx:90
 msgid "Defensive pact signed"
-msgstr "Pacto defensivo firmado"
+msgstr "Pacto de defensa firmado"
 
 #. placeholder {0}: ts.paper
 #: src/components/_military/battle/SetOrderFormModal.tsx:427
 msgid "Defensive pact: orders supporting your pact partner cost {orderDiscountPercent}% less <0>{0}</0>"
-msgstr "Pacto defensivo: los pedidos que apoyan a tu socio del pacto cuestan {orderDiscountPercent}% menos <0>{0}</0>"
+msgstr "Pacto de defensa: las órdenes que apoyan a tu aliado del pacto cuestan un {orderDiscountPercent}% menos <0>{0}</0>"
 
 #: src/components/_political/law/law.frontConfig.tsx:228
 msgid "Define <0/> as an enemy, increasing damages when fighting them"
-msgstr "Define <0/> como un enemigo, aumentando el daño al luchar contra ellos."
+msgstr "Definir a <0/> como enemigo principal, aumentando el daño al combatirlo"
 
 #: src/components/_political/law/law.frontConfig.tsx:218
 msgid "Define <0/> as enemy"
@@ -3293,7 +3293,7 @@ msgstr "Diplomático"
 #. placeholder {0}: ts.paper
 #: src/components/_political/law/LawEthicEffects.tsx:173
 msgid "Diplomatic: defensive pact maintenance costs {less}% less <0>{0}</0>."
-msgstr "Diplomático: los costos de mantenimiento del pacto defensivo {menos}% menos <0>{0}</0>."
+msgstr "Diplomático: los costes de mantenimiento de pactos de defensa son {less}% menores <0>{0}</0>."
 
 #: src/components/_economy/company/CompanyDropdown.tsx:189
 msgid "Disable company"
@@ -3305,7 +3305,7 @@ msgstr "Desactivada"
 
 #: src/components/_political/alliance/AllianceHeader.tsx:73
 msgid "Disbanded <0/>"
-msgstr "Disuelta <0/>"
+msgstr "Disolvió <0/>"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:176
 #: src/pages/user/[userId]/inventory.tsx:49
@@ -3331,7 +3331,7 @@ msgstr "Disolver alianza"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:173
 msgid "Dissolve the alliance permanently, removing every member country."
-msgstr "Disolver la alianza de forma permanente, eliminando a todos los países miembros."
+msgstr "Disolver permanentemente la alianza, eliminando todos los países miembros."
 
 #: src/components/_military/damageRanking/BattleLoot.tsx:97
 msgid "Distributed"
@@ -3484,7 +3484,7 @@ msgstr "Pechera de Élite"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:45
 msgid "Elite counter-terrorism unit"
-msgstr "Unidad de élite antiterrorista"
+msgstr "Unidad élite antiterrorista"
 
 #: src/utils/translations.tsx:215
 msgid "Elite Gloves"
@@ -3526,11 +3526,11 @@ msgstr "Pantalones encantados"
 
 #: src/components/_political/law/law.frontConfig.tsx:307
 msgid "End an existing defensive pact with another country"
-msgstr "Poner fin a un pacto defensivo existente con otro país."
+msgstr "Finalizar un pacto de defensa existente con otro país"
 
 #: src/components/_political/law/law.frontConfig.tsx:321
 msgid "End the defensive pact with <0/>."
-msgstr "Finaliza el pacto defensivo con <0/>."
+msgstr "Finalizar el pacto de defensa con <0/>."
 
 #: src/components/_military/battle/BattleSystem.tsx:743
 msgid "Ended"
@@ -3705,7 +3705,7 @@ msgstr "Agrarista fanático"
 
 #: src/components/_political/law/LawEthicEffects.tsx:58
 msgid "Fanatic Agrarian countries cannot pick a specialization — this law cannot be enacted."
-msgstr "Los países agrarios fanáticos no pueden elegir una especialización; esta ley no puede promulgarse."
+msgstr "Los países Agrarios Fanáticos no pueden elegir una especialización; esta ley no puede promulgarse."
 
 #: src/components/_political/party/party.frontConfig.tsx:211
 msgid "Fanatic Diplomatic"
@@ -3714,12 +3714,12 @@ msgstr "Diplomático fanático"
 #. placeholder {0}: ts.paper
 #: src/components/_political/law/LawEthicEffects.tsx:160
 msgid "Fanatic Diplomatic: defensive pact maintenance costs {less}% less <0>{0}</0>."
-msgstr "Diplomático fanático: los costos de mantenimiento del pacto defensivo son {menos}% menos <0>{0}</0>."
+msgstr "Diplomático Fanático: los costes de mantenimiento de pactos de defensa son {less}% menores <0>{0}</0>."
 
 #. placeholder {0}: ts.paper
 #: src/components/_political/law/LawEthicEffects.tsx:143
 msgid "Fanatic Diplomatic: sworn enemy maintenance costs {more}% more <0>{0}</0>."
-msgstr "Diplomático fanático: los costos de mantenimiento del enemigo jurado {más}% más <0>{0}</0>."
+msgstr "Diplomático Fanático: los costes de mantenimiento de enemigos principales son {more}% mayores <0>{0}</0>."
 
 #: src/components/_political/party/party.frontConfig.tsx:105
 msgid "Fanatic Expansionist"
@@ -3740,11 +3740,11 @@ msgstr "Aislacionista fanático"
 #. placeholder {0}: ts.paper
 #: src/components/_political/law/LawEthicEffects.tsx:188
 msgid "Fanatic Isolationist: all treaty maintenance costs {more}% more <0>{0}</0>."
-msgstr "Aislacionista fanático: todos los costos de mantenimiento de tratados {more}% más <0>{0}</0>."
+msgstr "Aislacionista fanático: todos los costes de mantenimiento de tratados son {more}% mayores <0>{0}</0>."
 
 #: src/components/_political/law/LawEthicEffects.tsx:114
 msgid "Fanatic Isolationist: this sworn enemy starts at {start}% bonus and grows +{perDay}% per day."
-msgstr "Aislado fanático: este enemigo jurado comienza con una bonificación del {start}% y crece +{perDay}% por día."
+msgstr "Aislacionista fanático: este enemigo principal comienza con una bonificación del {start}% y aumenta un +{perDay}% por día."
 
 #: src/components/_political/party/party.frontConfig.tsx:56
 msgid "Fanatic Pacifist"
@@ -3752,7 +3752,7 @@ msgstr "Pacifista fanático"
 
 #: src/components/_political/law/LawEthicEffects.tsx:94
 msgid "Fanatic Pacifist countries cannot have sworn enemies — this law cannot be enacted."
-msgstr "Los países pacifistas fanáticos no pueden tener enemigos jurados; esta ley no puede promulgarse."
+msgstr "Los países Pacifistas fanáticos no pueden tener enemigos principales; esta ley no puede promulgarse."
 
 #: src/components/_political/party/party.frontConfig.tsx:251
 msgid "Fanatic Republican"
@@ -3843,17 +3843,17 @@ msgstr "Financiar una batalla de Resistencia en <0/>"
 
 #: src/components/_political/partyMotion/partyMotion.frontConfig.tsx:123
 msgid "Finance a resistance battle in an occupied region of your country"
-msgstr "Financiar una batalla de Resistencia en una region ocupada por tu país"
+msgstr "Financiar una batalla de Resistencia en una región ocupada por tu país"
 
-#: src/components/_political/law/law.frontConfig.tsx:614
+#: src/components/_political/law/law.frontConfig.tsx:615
 msgid "Finance a resistance to liberate an occupied region"
-msgstr "Financiar una Resistencia para liberar una region ocupada"
+msgstr "Financiar una Resistencia para liberar una región ocupada"
 
-#: src/components/_political/law/law.frontConfig.tsx:627
+#: src/components/_political/law/law.frontConfig.tsx:628
 msgid "Finance a revolt to liberate <0/>"
 msgstr "Financiar una revuelta para liberar <0/>"
 
-#: src/components/_political/law/law.frontConfig.tsx:613
+#: src/components/_political/law/law.frontConfig.tsx:614
 #: src/components/_political/law/lawNames.tsx:38
 msgid "Finance foreign resistance"
 msgstr "Financiar una resistencia extranjera"
@@ -3862,7 +3862,7 @@ msgstr "Financiar una resistencia extranjera"
 msgid "Finance local resistance"
 msgstr "Financiar una resistencia local"
 
-#: src/components/_political/law/law.frontConfig.tsx:618
+#: src/components/_political/law/law.frontConfig.tsx:619
 msgid "Finance resistance in <0/>"
 msgstr "Financiar la resistencia en <0/>"
 
@@ -3935,7 +3935,7 @@ msgstr "para empresas produciendo <0>{0}</0> ubicadas en <1/>."
 
 #: src/components/_political/law/law.frontConfig.tsx:333
 msgid "Found a new alliance with your country as founding member"
-msgstr "Se ha formado una nueva alianza con su país como miembro fundador."
+msgstr "Fundar una nueva alianza con tu país como miembro fundador"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:45
 msgid "Founding Father"
@@ -3951,19 +3951,19 @@ msgstr "Dato curioso: La casa siempre gana"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:275
 msgid "Fur Boots"
-msgstr "Botas de piel"
+msgstr "Botas de Piel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:278
 msgid "Fur Loincloth"
-msgstr "Taparrabos de piel"
+msgstr "Taparrabos de Piel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:281
 msgid "Fur Mittens"
-msgstr "Guantes de piel"
+msgstr "Mitones de Piel"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:272
 msgid "Fur Tunic"
-msgstr "Túnica de piel"
+msgstr "Túnica de Piel"
 
 #: src/components/_common/GameRules.tsx:234
 msgid "g. The use of profiles (picture, description, name) related to aforementioned ideologies and movements as well as political figures linked to ongoing real-world wars and armed conflicts. Humoristic names, descriptions and pictures are tolerated, with the exception of any content related to nazism and neo-nazism."
@@ -4091,7 +4091,7 @@ msgstr "Gobierno"
 
 #: src/components/_political/government/GovernmentAnnouncementModal.tsx:47
 msgid "Government announcement"
-msgstr "Anuncio del gobierno"
+msgstr "Anuncio gubernamental"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:234
 msgid "Government Member"
@@ -4199,51 +4199,51 @@ msgstr "Puntos de terreno"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:338
 msgid "GSG9 Armored Tank"
-msgstr "GSG9 Tanque Blindado"
+msgstr "Tanque Blindado GSG9"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:332
 msgid "GSG9 Assault Rifle"
-msgstr "GSG9 Rifle de asalto"
+msgstr "Rifle de Asalto GSG9"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:341
 msgid "GSG9 Combat Helicopter"
-msgstr "GSG9 Helicóptero de Combate"
+msgstr "Helicóptero de Combate GSG9"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:44
 msgid "GSG9 Pack"
-msgstr "GSG9 Paquete"
+msgstr "Paquete GSG9"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:329
 msgid "GSG9 Pistol"
-msgstr "GSG9 Pistola"
+msgstr "Pistola GSG9"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:335
 msgid "GSG9 Sniper Rifle"
-msgstr "GSG9 Rifle de Francotirador"
+msgstr "Rifle de Francotirador GSG9"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:350
 msgid "GSG9 Tactical Boots"
-msgstr "GSG9 Botas Tácticas"
+msgstr "Botas Tácticas GSG9"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:356
 msgid "GSG9 Tactical Gloves"
-msgstr "GSG9 Guantes Tácticos"
+msgstr "Guantes Tácticos GSG9"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:344
 msgid "GSG9 Tactical Helmet"
-msgstr "GSG9 Casco Táctico"
+msgstr "Casco Táctico GSG9"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:353
 msgid "GSG9 Tactical Pants"
-msgstr "GSG9 Pantalones Tácticos"
+msgstr "Pantalones Tácticos GSG9"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:326
 msgid "GSG9 Tactical Shield"
-msgstr "GSG9 Escudo táctico"
+msgstr "Escudo Táctico GSG9"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:347
 msgid "GSG9 Tactical Vest"
-msgstr "GSG9 Chaleco táctico"
+msgstr "Chaleco Táctico GSG9"
 
 #: src/utils/translations.tsx:23
 msgid "Gun"
@@ -4484,11 +4484,11 @@ msgstr "Invitaciones"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:46
 msgid "Invite <0/>"
-msgstr "Invitar <0/>"
+msgstr "Invitar a <0/>"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:55
 msgid "Invite <0/> to join the alliance. If accepted, the target country's government must also accept a system law before joining takes effect."
-msgstr "Invitar a <0/> a unirse a la alianza. Si se acepta, el gobierno del país objetivo también debe aprobar una ley del sistema antes de que la adhesión entre en vigor."
+msgstr "Invita a <0/> a unirse a la alianza. Si acepta, el gobierno del país objetivo también deberá aprobar una ley del sistema antes de que la adhesión surta efecto."
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:39
 msgid "Invite a country to join the alliance. A confirmation law is created in the target country."
@@ -4514,7 +4514,7 @@ msgstr "Aislacionista"
 
 #: src/components/_political/law/LawEthicEffects.tsx:128
 msgid "Isolationist: this sworn enemy starts at {start}% bonus and grows +{perDay}% per day."
-msgstr "Aislacionista: este enemigo jurado comienza con una bonificación del {start}% y crece +{perDay}% por día."
+msgstr "Aislacionista: este enemigo principal comienza con una bonificación del {start}% y crece +{perDay}% por día."
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:9
 msgid "It only gets better… maybe"
@@ -4562,15 +4562,15 @@ msgstr "Ofertas de trabajo"
 msgid "Jobs"
 msgstr "Trabajos"
 
-#: src/components/_political/law/law.frontConfig.tsx:384
+#: src/components/_political/law/law.frontConfig.tsx:385
 msgid "Join <0/>"
-msgstr "Unirse <0/>"
+msgstr "Unirse a <0/>"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:368
 msgid "Join a Military Unit"
 msgstr "Únete a una Unidad Militar"
 
-#: src/components/_political/law/law.frontConfig.tsx:378
+#: src/components/_political/law/law.frontConfig.tsx:379
 #: src/components/_political/law/lawNames.tsx:27
 msgid "Join alliance"
 msgstr "Unirse a la alianza"
@@ -4589,7 +4589,7 @@ msgstr "¡Únete al chat de tu país!"
 
 #: src/components/_political/chat/ChatConversationsMenu.tsx:156
 msgid "Joinable"
-msgstr "Unible"
+msgstr "Disponible para unirse"
 
 #: src/components/_user/worker/WorkerItem.tsx:150
 msgid "Joined"
@@ -4629,7 +4629,7 @@ msgstr "Expulsar"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:73
 msgid "Kick <0/>"
-msgstr "Expulsar <0/>"
+msgstr "Expulsar a <0/>"
 
 #: src/components/_political/alliance/alliance.frontConfig.tsx:16
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:65
@@ -4642,7 +4642,7 @@ msgstr "Expulsar miembro"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:263
 msgid "Knapped Flints"
-msgstr "Pedernal Tallado"
+msgstr "Pedernales Tallados"
 
 #: src/utils/translations.tsx:22
 msgid "Knife"
@@ -4726,7 +4726,7 @@ msgstr "Plomo"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:248
 msgid "Leather Sling"
-msgstr "Correa de Cuero"
+msgstr "Honda de Cuero"
 
 #: src/components/_economy/company/CompanyDropdown.tsx:221
 msgid "Leave"
@@ -4734,16 +4734,16 @@ msgstr "Renunciar"
 
 #: src/components/_political/law/law.frontConfig.tsx:359
 msgid "Leave <0/>"
-msgstr "Renunciar <0/>"
+msgstr "Abandonar <0/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:368
 msgid "Leave <0/>."
-msgstr "Renunciar <0/>."
+msgstr "Abandonar <0/>."
 
 #: src/components/_political/law/law.frontConfig.tsx:353
 #: src/components/_political/law/lawNames.tsx:26
 msgid "Leave alliance"
-msgstr "Dejar alianza"
+msgstr "Abandonar alianza"
 
 #: src/components/_user/worker/WageReductionAlert.tsx:55
 msgid "Leave company?"
@@ -4761,11 +4761,11 @@ msgstr "Dimitir del gobierno"
 
 #: src/components/_political/law/law.frontConfig.tsx:354
 msgid "Leave the alliance your country belongs to"
-msgstr "Abandona la alianza a la que pertenece tu país."
+msgstr "Abandonar la alianza a la que pertenece tu país"
 
 #: src/components/_political/alliance/AllianceHeader.tsx:80
 msgid "Led by <0/>."
-msgstr "Liderada por <0/>"
+msgstr "Liderada por <0/>."
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:78
 msgid "Legend spotted!"
@@ -4799,7 +4799,7 @@ msgstr "Nivel {level}"
 #: src/components/_political/election/Election.tsx:132
 #: src/components/_political/election/Election.tsx:224
 msgid "Level too low"
-msgstr "Nivel muy bajo"
+msgstr "Nivel demasiado bajo"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:107
 msgid "Level up your skills!"
@@ -4809,15 +4809,15 @@ msgstr "¡Sube de nivel tus habilidades!"
 msgid "Level up!"
 msgstr "¡Subiste de nivel!"
 
-#: src/components/_political/law/law.frontConfig.tsx:498
+#: src/components/_political/law/law.frontConfig.tsx:499
 msgid "Liberate <0/>"
 msgstr "Liberar <0/>"
 
-#: src/components/_political/law/law.frontConfig.tsx:507
+#: src/components/_political/law/law.frontConfig.tsx:508
 msgid "Liberate <0/> and return it to its original country"
 msgstr "Liberar <0/> y devolverla a su país original"
 
-#: src/components/_political/law/law.frontConfig.tsx:493
+#: src/components/_political/law/law.frontConfig.tsx:494
 #: src/components/_political/law/lawNames.tsx:32
 msgid "Liberate a region"
 msgstr "Liberar una región"
@@ -4958,7 +4958,7 @@ msgstr "Mayor"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:110
 msgid "Make <0/> the new alliance leader. The leader can edit the alliance avatar and color scheme directly."
-msgstr "Nombra a <0/> como el nuevo líder de la alianza. El líder podrá editar directamente el avatar y la combinación de colores de la alianza."
+msgstr "Nombrar a <0/> como nuevo líder de la alianza. El líder puede editar directamente el avatar y el esquema de colores de la alianza."
 
 #: src/components/_user/premium/PremiumActions.tsx:81
 msgid "Manage Subscription"
@@ -5082,7 +5082,7 @@ msgstr "Países miembros"
 
 #: src/components/_political/allianceLaw/AllianceLawFormModal.tsx:153
 msgid "Member country to kick"
-msgstr "País miembro para expulsar"
+msgstr "País miembro a expulsar"
 
 #: src/components/_military/mu/MuMemberList.tsx:116
 msgid "Member demoted from commander"
@@ -5106,7 +5106,7 @@ msgstr "Miembro ascendido a comandante"
 msgid "Members"
 msgstr "Miembros"
 
-#: src/components/_political/alliance/AllianceMemberRow.tsx:46
+#: src/components/_political/alliance/AllianceMemberRow.tsx:45
 msgid "Membership suspended"
 msgstr "Membresía suspendida"
 
@@ -5158,7 +5158,7 @@ msgstr "Base militar"
 #: src/components/_political/party/party.frontConfig.tsx:95
 #: src/components/_political/party/party.frontConfig.tsx:109
 msgid "Military bases can be upgraded or downgraded every <0>{0} hours</0>."
-msgstr "Las bases militares pueden ser mejoradas o degradadas cada <0>{0} horas</0>."
+msgstr "Las bases militares pueden mejorarse o degradarse cada <0>{0} horas</0>."
 
 #: src/components/_political/law/LawTypeSelect.tsx:76
 msgid "Military laws"
@@ -5402,11 +5402,11 @@ msgstr "Nombre"
 
 #: src/components/_political/party/party.frontConfig.tsx:425
 msgid "National battle orders cost double."
-msgstr "Las órdenes de guerra nacionales cuestan el doble."
+msgstr "Las órdenes de batalla nacionales cuestan el doble."
 
 #: src/components/_political/party/party.frontConfig.tsx:419
 msgid "National battle orders give <0>double</0> the priority damage bonus (<1>+10%</1> / <2>+20%</2> / <3>+30%</3>)."
-msgstr "Las órdenes de batalla nacionales otorgan <0>doble</0> de la bonificación de daño prioritario (<1>+10%</1> / <2>+20%</2> / <3>+30%</3>)."
+msgstr "Las órdenes de batalla nacionales otorgan el <0>doble</0> de la bonificación de daño prioritario (<1>+10%</1> / <2>+20%</2> / <3>+30%</3>)."
 
 #: src/components/_military/battle/BattleSystem.tsx:798
 msgid "National bounty"
@@ -5441,7 +5441,7 @@ msgstr "Nuevo"
 #: src/components/_political/allianceLaw/AllianceLawFormModal.tsx:172
 #: src/components/_political/allianceLaw/AllianceLawFormModal.tsx:173
 msgid "New alliance name"
-msgstr "Nombre de la nueva alianza"
+msgstr "Nuevo nombre de la alianza"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:122
 msgid "New API Token Created"
@@ -5475,7 +5475,7 @@ msgstr "Nueva oferta de trabajo"
 
 #: src/components/_political/allianceLaw/AllianceLawFormModal.tsx:161
 msgid "New leader"
-msgstr "Nuevo lider"
+msgstr "Nuevo líder"
 
 #: src/components/_economy/company/MoveCompanyForm.tsx:77
 msgid "New location"
@@ -5583,7 +5583,7 @@ msgstr "Sin ideologías activas - Balanceado"
 msgid "No active job offer"
 msgstr "No hay oferta de trabajo activa"
 
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:267
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:262
 msgid "No active wars"
 msgstr "Ninguna guerra activa"
 
@@ -5597,7 +5597,7 @@ msgstr "Sin bonificación de alianza: la membresía de su país está suspendida
 
 #: src/components/_political/allianceLaw/AllianceLawList.tsx:50
 msgid "No alliance laws yet"
-msgstr "Aún no hay leyes de alianza."
+msgstr "Aún no hay leyes de alianza"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:231
 msgid "No API tokens yet. Create one to get started."
@@ -5631,9 +5631,9 @@ msgstr "Aún no hay contribuciones"
 msgid "No damages ranking yet."
 msgstr "Aún no hay ranking de daño."
 
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:393
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:388
 msgid "No defensive pact"
-msgstr "Sin pacto defensivo"
+msgstr "Sin pacto de defensa"
 
 #: src/components/_economy/donation/DonationList.tsx:81
 msgid "No donations yet"
@@ -5712,7 +5712,7 @@ msgstr "Aún no hay recomendador"
 msgid "No skins equipped"
 msgstr "Sin skins equipadas"
 
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:326
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:321
 msgid "No sworn enemy"
 msgstr "Sin enemigo principal"
 
@@ -5740,7 +5740,7 @@ msgstr "Nombrar"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:100
 msgid "Nominate <0/> as leader"
-msgstr "Nominar a <0/> como líder"
+msgstr "Nominar a <0/> como lider"
 
 #: src/components/_political/government/Government.tsx:282
 msgid "Nominate a {title}"
@@ -5748,7 +5748,7 @@ msgstr "Nombrar a {title}"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:93
 msgid "Nominate a citizen of a member country as the alliance leader."
-msgstr "Nombrar a un ciudadano de un país miembro como líder de la alianza."
+msgstr "Nominar a un ciudadano de un país miembro como líder de la alianza."
 
 #: src/components/_political/alliance/alliance.frontConfig.tsx:17
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:91
@@ -5772,7 +5772,7 @@ msgstr "No todas las formas de ayuda se consideran boosting o explotación; la i
 msgid "Not bad!"
 msgstr "¡Nada mal!"
 
-#: src/components/_political/alliance/AllianceMemberRow.tsx:47
+#: src/components/_political/alliance/AllianceMemberRow.tsx:46
 msgid "Not enough paper to pay the daily alliance maintenance. Alliance damage bonuses are disabled for this country until it pays."
 msgstr "No hay suficiente papel para pagar el mantenimiento diario de la alianza. Las bonificaciones por daño de la alianza están desactivadas para este país hasta que pague."
 
@@ -5780,9 +5780,9 @@ msgstr "No hay suficiente papel para pagar el mantenimiento diario de la alianza
 msgid "Not impressive, but not shameful"
 msgstr "No impresionante, pero tampoco vergonzoso"
 
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:208
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:207
 msgid "Not in any alliance"
-msgstr "No está en ninguna alianza."
+msgstr "No pertenece a ninguna alianza"
 
 #: src/pages/notifications.tsx:38
 #: src/pages/user/[userId]/settings.tsx:79
@@ -5803,7 +5803,7 @@ msgstr "Número de donantes:"
 
 #: src/components/_political/partyMotion/PartyMotionFormModal.tsx:142
 msgid "Occupied region"
-msgstr "Region ocupada"
+msgstr "Región ocupada"
 
 #: src/components/_political/government/Government.tsx:204
 msgid "of"
@@ -5856,7 +5856,7 @@ msgstr "Solo los supporters pueden ver el desglose de sus gastos e ingresos."
 
 #: src/components/_political/party/party.frontConfig.tsx:264
 msgid "Only your core regions generate development income."
-msgstr "Solo tus regiones principales generan ingresos para el desarrollo."
+msgstr "Solo tus regiones nacionales generan ingresos de desarrollo."
 
 #: src/components/_economy/inventory/case/OpenCaseModal.tsx:521
 msgid "Open"
@@ -5995,7 +5995,7 @@ msgstr "Pacifista"
 #. placeholder {0}: ts.paper
 #: src/components/_military/battle/SetOrderFormModal.tsx:439
 msgid "Pacifist: orders defending your core regions or revolts cost {orderDiscountPercent}% less <0>{0}</0>"
-msgstr "Pacifista: las órdenes para defender tus regiones centrales o revueltas cuestan {orderDiscountPercent}% menos <0>{0}</0>"
+msgstr "Pacifista: las órdenes para defender tus regiones nacionales o revueltas cuestan un {orderDiscountPercent}% menos <0>{0}</0>"
 
 #: src/components/_other/shop/ShopHeader.tsx:29
 msgid "Packs"
@@ -6127,7 +6127,7 @@ msgstr "La gente está enojada, ha comenzado una revuelta automática en <0/>"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:169
 msgid "Permanently dissolve the alliance."
-msgstr "Disolver la alianza de forma permanente."
+msgstr "Disolver permanentemente la alianza."
 
 #: src/utils/translations.tsx:86
 msgid "Petroleum"
@@ -6319,7 +6319,7 @@ msgstr "Produce artículos <0>{count}</0> veces"
 
 #: src/utils/translations.tsx:91
 msgid "Produced from Wood"
-msgstr "Fabricado en madera"
+msgstr "Producido a partir de Madera"
 
 #: src/components/_economy/company/CompanyChangeItemFormModal.tsx:71
 msgid "Produced item"
@@ -6377,7 +6377,7 @@ msgstr "Ascendido a Comandante"
 
 #: src/components/_political/law/law.frontConfig.tsx:259
 msgid "Propose a defensive pact with <0/>"
-msgstr "Proponer un pacto defensivo con <0/>"
+msgstr "Proponer un pacto de defensa a <0/>"
 
 #: src/components/_political/partyMotion/PartyMotionFormModal.tsx:125
 #: src/components/_political/partyMotion/PartyMotionList.tsx:48
@@ -6386,21 +6386,21 @@ msgstr "Proponer una moción"
 
 #: src/components/_political/law/law.frontConfig.tsx:268
 msgid "Propose a mutual defensive pact with <0/>. Once accepted, defenders of either country get a bonus that starts at 1% and grows +1% per day up to 10%."
-msgstr "Proponer un pacto de defensa mutua con <0/>. Una vez aceptado, los defensores de cualquiera de los dos países recibirán una bonificación que comienza en el 1% y aumenta un 1% diario hasta un máximo del 10%."
+msgstr "Proponer un pacto de defensa mutua a <0/>. Una vez aceptado, los defensores de cualquiera de los dos países reciben una bonificación que comienza en 1% y aumenta +1% por día hasta un máximo de 10%."
 
 #: src/components/_political/law/law.frontConfig.tsx:254
 msgid "Propose a mutual defensive pact with another country to get a growing defensive bonus"
-msgstr "Proponer un pacto defensivo mutuo con otro país para obtener una bonificación defensiva creciente."
+msgstr "Propón un pacto de defensa mutua con otro país para obtener una bonificación defensiva creciente."
 
 #: src/components/_political/allianceLaw/AllianceLawFormModal.tsx:125
 #: src/components/_political/allianceLaw/AllianceLawList.tsx:36
 msgid "Propose alliance law"
-msgstr "Proponer una ley de alianzas"
+msgstr "Proponer ley de alianza"
 
 #: src/components/_political/law/law.frontConfig.tsx:252
 #: src/components/_political/law/lawNames.tsx:40
 msgid "Propose defensive pact"
-msgstr "Proponer un pacto defensivo"
+msgstr "Proponer pacto de defensa"
 
 #: src/components/_political/allianceLaw/AllianceLawFormModal.tsx:198
 #: src/components/_political/law/LawFormModal.tsx:347
@@ -6426,16 +6426,16 @@ msgid "Propose peace to another country"
 msgstr "Proponer paz con otro país"
 
 #. placeholder {0}: law.data.amount ?? 0
-#: src/components/_political/law/law.frontConfig.tsx:482
+#: src/components/_political/law/law.frontConfig.tsx:483
 msgid "Propose to buy <0/> from <1/> for <2>{0}</2>"
 msgstr "Proponer comprar la región <0/> de <1/> por <2>{0}</2>"
 
-#: src/components/_political/law/law.frontConfig.tsx:466
+#: src/components/_political/law/law.frontConfig.tsx:467
 #: src/components/_political/law/lawNames.tsx:31
 msgid "Propose to buy a region"
 msgstr "Proponer comprar una región"
 
-#: src/components/_political/law/law.frontConfig.tsx:467
+#: src/components/_political/law/law.frontConfig.tsx:468
 msgid "Propose to buy a region from another country"
 msgstr "Proponer comprar una región de otro país"
 
@@ -6636,7 +6636,7 @@ msgstr "Regenera <0>{0}</0> al consumirse"
 msgid "Region"
 msgstr "Región"
 
-#: src/components/_political/law/law.frontConfig.tsx:438
+#: src/components/_political/law/law.frontConfig.tsx:439
 #: src/components/_political/law/lawNames.tsx:30
 msgid "Region buy offer"
 msgstr "Oferta de compra de región"
@@ -6656,7 +6656,7 @@ msgstr "Transferencia de región"
 #. placeholder {0}: formatMultiplierDelta( ethicsBonuses.imperialism[2].upgradeMaintenanceMultiplier, )
 #: src/components/_political/party/party.frontConfig.tsx:316
 msgid "Region upgrade maintenance costs are increased by <0>{0}</0>."
-msgstr "Los costos de mantenimiento de la actualización de la región aumentan en <0>{0}</0>."
+msgstr "Los costes de mantenimiento de mejoras regionales aumentan en <0>{0}</0>."
 
 #: src/components/_layout/LoadingScreenContent.tsx:20
 msgid "regions"
@@ -6721,7 +6721,7 @@ msgstr "Destituir a <0/> del parlamento por inactividad"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:82
 msgid "Remove <0/> from the alliance immediately on acceptance."
-msgstr "Eliminar <0/> de la alianza inmediatamente después de su aceptación."
+msgstr "Eliminar a <0/> de la alianza inmediatamente al ser aceptado."
 
 #: src/components/_political/partyMotion/partyMotion.frontConfig.tsx:38
 msgid "Remove <0/> from the party council"
@@ -6729,7 +6729,7 @@ msgstr "Remover <0/> del partido del consejo"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:66
 msgid "Remove a member country from the alliance."
-msgstr "Retirar a un país miembro de la alianza."
+msgstr "Eliminar un país miembro de la alianza."
 
 #: src/components/_political/partyMotion/partyMotion.frontConfig.tsx:32
 msgid "Remove a member from the party council"
@@ -6765,7 +6765,7 @@ msgstr "Remover un miembro del consejo"
 msgid "Remove Description"
 msgstr "Eliminar descripción"
 
-#: src/components/_political/law/law.frontConfig.tsx:428
+#: src/components/_political/law/law.frontConfig.tsx:429
 #: src/components/_political/law/lawNames.tsx:29
 msgid "Remove enemy"
 msgstr "Eliminar enemigo principal"
@@ -6786,12 +6786,12 @@ msgstr "Renombrar"
 #: src/components/_political/alliance/alliance.frontConfig.tsx:18
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:120
 msgid "Rename alliance"
-msgstr "Cambiar el nombre de la alianza"
+msgstr "Renombrar alianza"
 
 #. placeholder {0}: data.newName
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:127
 msgid "Rename alliance to \"{0}\""
-msgstr "Cambiar el nombre de la alianza a \"{0}\""
+msgstr "Renombrar alianza a \"{0}\""
 
 #: src/components/_economy/company/CompanyRenameFormModal.tsx:66
 #: src/components/_economy/company/CompanyRenameFormModal.tsx:82
@@ -6801,7 +6801,7 @@ msgstr "Renombrar empresa"
 #. placeholder {0}: data.newName
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:133
 msgid "Rename the alliance to \"{0}\" immediately on acceptance."
-msgstr "Cambie el nombre de la alianza a \"{0}\" inmediatamente después de su aceptación."
+msgstr "Renombrar la alianza a \"{0}\" inmediatamente al ser aceptado."
 
 #: src/components/_political/government/Government.tsx:244
 msgid "Replace"
@@ -6829,7 +6829,7 @@ msgstr "Reportar usuario"
 
 #: src/components/_user/user/UserHeader.tsx:192
 msgid "Reports"
-msgstr "Reportes"
+msgstr "Informes"
 
 #: src/components/_political/party/party.frontConfig.tsx:270
 #: src/components/_political/party/party.frontConfig.tsx:285
@@ -6894,7 +6894,7 @@ msgstr "Contribuidores de la resistencia"
 
 #: src/components/_military/battle/BattleName.tsx:152
 msgid "Resistance for {regionName} {score}"
-msgstr "Resistencia para {regionName} {score}"
+msgstr "Resistencia por {regionName} {score}"
 
 #: src/pages/country/[countryId]/index.tsx:226
 #: src/pages/region/[regionId]/index.tsx:49
@@ -6913,7 +6913,7 @@ msgstr "Respuesta a mensaje"
 msgid "Restore your health!"
 msgstr "¡Restaura tu salud!"
 
-#: src/components/_political/law/law.frontConfig.tsx:494
+#: src/components/_political/law/law.frontConfig.tsx:495
 msgid "Return a region to its original country"
 msgstr "Devolver una región a su país original"
 
@@ -6931,11 +6931,11 @@ msgstr "Revolución {score}"
 
 #: src/components/_political/event/EventList.tsx:97
 msgid "Revolution ended"
-msgstr "La revolución terminó"
+msgstr "La revuelta terminó"
 
 #: src/components/_political/event/EventList.tsx:96
 msgid "Revolution started"
-msgstr "Revolución iniciada"
+msgstr "Revuela iniciada"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2035
 msgid "Revolution started!"
@@ -7167,7 +7167,7 @@ msgstr "Precio de venta:"
 msgid "sells"
 msgstr "vende"
 
-#: src/components/_political/law/law.frontConfig.tsx:418
+#: src/components/_political/law/law.frontConfig.tsx:419
 msgid "Send <0/> to <1/>"
 msgstr "Enviar <0/> a <1/>"
 
@@ -7197,9 +7197,9 @@ msgstr "Enviar mensaje"
 
 #. placeholder {0}: staticGameConfig.law[ELawType.SEND_MONEY_TO_COUNTRY].allianceTaxRate * 100
 #. placeholder {1}: staticGameConfig.law[ELawType.SEND_MONEY_TO_COUNTRY].externalTaxRate * 100
-#: src/components/_political/law/law.frontConfig.tsx:404
+#: src/components/_political/law/law.frontConfig.tsx:405
 msgid "Send money to another country. Paper tax on top: {0}% within your alliance, {1}% for external transfers."
-msgstr "Enviar dinero a otro país. Impuesto adicional sobre el papel: {0}% dentro de su alianza, {1}% para transferencias externas."
+msgstr "Enviar dinero a otro país. Impuesto de papel adicional: {0}% dentro de tu alianza y {1}% para transferencias externas."
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:51
 msgid "Sergeant"
@@ -7213,11 +7213,11 @@ msgstr "Establecer una <0>descripción</0>"
 msgid "Set a referrer"
 msgstr "Establecer un recomendador"
 
-#: src/components/_political/law/law.frontConfig.tsx:518
+#: src/components/_political/law/law.frontConfig.tsx:519
 msgid "Set a welcome article for your country"
 msgstr "Establecer un artículo de bienvenida para tu país"
 
-#: src/components/_political/law/law.frontConfig.tsx:523
+#: src/components/_political/law/law.frontConfig.tsx:524
 msgid "Set a welcome article for your country<0/>"
 msgstr "Establecer un artículo de bienvenida para tu país<0/>"
 
@@ -7225,13 +7225,13 @@ msgstr "Establecer un artículo de bienvenida para tu país<0/>"
 msgid "Set bounty"
 msgstr "Establecer recompensa"
 
-#: src/components/_political/law/law.frontConfig.tsx:544
+#: src/components/_political/law/law.frontConfig.tsx:545
 #: src/components/_political/law/lawNames.tsx:34
 msgid "Set country color"
 msgstr "Establecer color del país"
 
 #. placeholder {0}: law.data.scheme
-#: src/components/_political/law/law.frontConfig.tsx:536
+#: src/components/_political/law/law.frontConfig.tsx:537
 msgid "Set country color to <0>{0}</0> "
 msgstr "Establecer el color del país a <0>{0}</0>"
 
@@ -7251,17 +7251,17 @@ msgstr "Establecer ideologías del partido"
 msgid "Set Profile Picture"
 msgstr "Establecer foto de perfil"
 
-#: src/components/_political/law/law.frontConfig.tsx:590
+#: src/components/_political/law/law.frontConfig.tsx:591
 #: src/components/_political/law/lawNames.tsx:36
 msgid "Set specialization item"
 msgstr "Establecer producto de especialidad"
 
 #. placeholder {0}: ts[law.data.itemCode]
-#: src/components/_political/law/law.frontConfig.tsx:596
+#: src/components/_political/law/law.frontConfig.tsx:597
 msgid "Set the country's specialized item to <0>{0}</0>.<1/>The country strategic resources <2>Production Bonus</2> will be available for local companies producing this item."
 msgstr "Establecer el producto de especialidad del país en <0>{0}</0>.<1/>El <2>Bono de producción</2> de los recursos estratégicos del país estará disponible para las empresas locales que produzcan este producto."
 
-#: src/components/_political/law/law.frontConfig.tsx:591
+#: src/components/_political/law/law.frontConfig.tsx:592
 msgid "Set the country's specialized production item"
 msgstr "Establecer el producto de especialidad del país"
 
@@ -7269,7 +7269,7 @@ msgstr "Establecer el producto de especialidad del país"
 msgid "Set Username"
 msgstr "Establecer nombre de usuario"
 
-#: src/components/_political/law/law.frontConfig.tsx:517
+#: src/components/_political/law/law.frontConfig.tsx:518
 #: src/components/_political/law/lawNames.tsx:33
 msgid "Set welcome article"
 msgstr "Establecer artículo de bienvenida"
@@ -7397,7 +7397,7 @@ msgstr "Omitir tutorial"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:260
 msgid "Sling Stones"
-msgstr "Piedras de honda"
+msgstr "Piedras para Honda"
 
 #: src/utils/translations.tsx:25
 msgid "Sniper"
@@ -7441,7 +7441,7 @@ msgstr "Gastos"
 
 #: src/components/_political/country/CountryHeader.tsx:186
 msgid "Stable, conquest-proof strength. Still used for unrest, government wages and revolution cost. Other costs use <0>Average development</0>."
-msgstr "Fuerza estable e inmune a la conquista. Todavía se utiliza para disturbios, salarios gubernamentales y costos de revolución. Otros costos utilizan <0>Desarrollo promedio</0>."
+msgstr "Fuerza estable e inmune a la conquista. Sigue utilizándose para el descontento, los salarios gubernamentales y el coste de las revoluciones. Los demás costes utilizan el <0>Desarrollo promedio</0>."
 
 #: src/components/_political/law/law.frontConfig.tsx:169
 #: src/components/_political/law/law.frontConfig.tsx:171
@@ -7507,7 +7507,7 @@ msgstr "Empezando desde abajo..."
 #. placeholder {0}: gameConfig?.battle.enemyDamagesBonusPercent
 #: src/components/_political/law/law.frontConfig.tsx:237
 msgid "starts at 1% and grows +1% per day up to <0>{0}</0>"
-msgstr "comienza en 1% y crece +1% por día hasta <0>{0}</0>"
+msgstr "comienza en 1% y aumenta +1% por día hasta <0>{0}</0>"
 
 #: src/pages/events/index.tsx:117
 msgid "Starts soon..."
@@ -7544,7 +7544,7 @@ msgstr "Acero"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:245
 msgid "Stone Maul"
-msgstr "Mazo de piedra"
+msgstr "Maza de Piedra"
 
 #: src/components/_economy/company/CompanyTags.tsx:107
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:83
@@ -7640,14 +7640,14 @@ msgstr "El Plan Supporter te permite guardar hasta {maxKits} configuraciones per
 msgid "Supreme Commander"
 msgstr "Comandante supremo"
 
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:276
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:271
 msgid "Sworn enemy"
 msgstr "Enemigo principal"
 
 #. placeholder {0}: formatMultiplierDelta( ethicsBonuses.isolationism[2].enemyMaintenanceMultiplier, )
 #: src/components/_political/party/party.frontConfig.tsx:233
 msgid "Sworn enemy maintenance costs are increased by <0>{0}</0>."
-msgstr "Los costes de mantenimiento de los enemigos jurados aumentan en <0>{0}</0>."
+msgstr "Los costes de mantenimiento de enemigos principales aumentan en <0>{0}</0>."
 
 #. placeholder {0}: ethicsBonuses.isolationism['-1'].enemyFidelityStart
 #. placeholder {0}: ethicsBonuses.isolationism['-2'].enemyFidelityStart
@@ -7656,12 +7656,12 @@ msgstr "Los costes de mantenimiento de los enemigos jurados aumentan en <0>{0}</
 #: src/components/_political/party/party.frontConfig.tsx:141
 #: src/components/_political/party/party.frontConfig.tsx:177
 msgid "Sworn enemy treaties start at <0>{0} fidelity</0> and gain <1>{1}</1> each day."
-msgstr "Los tratados de enemigos jurados comienzan con una fidelidad de <0>{0}</0> y ganan <1>{1}</1> cada día."
+msgstr "Los tratados de enemigo principal comienzan con <0>{0} de fidelidad</0> y ganan <1>{1}</1> cada día."
 
 #. placeholder {0}: ts.paper
 #: src/components/_military/battle/SetOrderFormModal.tsx:433
 msgid "Sworn enemy: orders against your sworn enemy cost {orderDiscountPercent}% less <0>{0}</0>"
-msgstr "Enemigo jurado: las órdenes contra tu enemigo jurado cuestan {orderDiscountPercent}% menos <0>{0}</0>"
+msgstr "Enemigo principal: las órdenes contra tu enemigo principal cuestan un {orderDiscountPercent}% menos <0>{0}</0>"
 
 #: src/components/_political/event/EventList.tsx:72
 msgid "System revolt"
@@ -7759,7 +7759,7 @@ msgstr "El contrato ha sido revertido. <0>{0}</0> fue enviado de vuelta a <1/>."
 
 #: src/components/_political/law/LawCostExplanation.tsx:32
 msgid "The cost is the law's base cost scaled by your country's average development."
-msgstr "El costo es el costo base de la ley ajustado según el desarrollo promedio de su país."
+msgstr "El coste es el coste base de la ley escalado según el desarrollo promedio de tu país."
 
 #: src/components/_user/user/skills.frontConfig.tsx:59
 msgid "The damage factor increase of critical hits over normal hits"
@@ -7779,7 +7779,7 @@ msgstr "El efecto de tus buffs consumidos ha terminado. La fase de debuff ha com
 
 #: src/components/_political/alliance/AllianceBattleBonus.tsx:53
 msgid "The full bonus of <0/> applies up to <1/> share of global <2>Development</2>. Above that, the bonus drops by <3/> per percentage point of share over the plateau, down to <4/>."
-msgstr "La bonificación completa de <0/> se aplica hasta <1/> participación en el <2>Desarrollo</2> global. Por encima de eso, la bonificación se reduce en <3/> por cada punto porcentual de participación sobre la meseta, hasta <4/>."
+msgstr "La bonificación completa de <0/> se aplica hasta una participación de <1/> del <2>Desarrollo</2> global. Por encima de ese límite, la bonificación se reduce en <3/> por cada punto porcentual de participación que exceda el umbral, hasta un mínimo de <4/>."
 
 #. placeholder {0}: Math.round(contract.moneyPool * 10) / 100
 #: src/components/_military/mercenaryContract/MercenaryContractItem.tsx:85
@@ -7829,7 +7829,7 @@ msgstr "Este país no tiene presidente ni parlamento activo, por lo que puedes t
 
 #: src/components/_political/government/Government.tsx:72
 msgid "This country is Fanatic Imperialist: it cannot have ministers, only a president and vice president. Minister nominations will be rejected."
-msgstr "Este país es un imperialista fanático: no puede tener ministros, solo un presidente y un vicepresidente. Las candidaturas a ministros serán rechazadas."
+msgstr "Este país es Imperialista Fanático: no puede tener ministros, solo un presidente y un vicepresidente. Las nominaciones de ministros serán rechazadas."
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:42
 msgid "This equipment is green and so is grass"
@@ -7845,7 +7845,7 @@ msgstr "Este es un resumen del botín que recibiste de esta batalla. Incluye cua
 
 #: src/components/_political/country/CountryHeader.tsx:215
 msgid "This is the value used to calculate most costs: battle orders, alliance, sworn enemy and defensive pact maintenance, laws and upgrade upkeep."
-msgstr "Este es el valor que se utiliza para calcular la mayoría de los costes: órdenes de batalla, alianzas, enemigos jurados, mantenimiento de pactos defensivos, leyes y mantenimiento de mejoras."
+msgstr "Este es el valor utilizado para calcular la mayoría de los costes: órdenes de batalla, mantenimiento de la alianza, del enemigo principal y del pacto de defensa leyes y mantenimiento de mejoras."
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:27
 msgid "This is your company hub. Here you can produce items and build your empire."
@@ -8065,7 +8065,7 @@ msgstr "Daños totales"
 msgid "Total Donated:"
 msgstr "Total donado:"
 
-#: src/components/_political/country/CountryDiplomacyGrid.tsx:399
+#: src/components/_political/country/CountryDiplomacyGrid.tsx:394
 msgid "Total of <0>{totalMaintenanceCostPerDay}</0>/day"
 msgstr "Total de <0>{totalMaintenanceCostPerDay}</0>/día"
 
@@ -8144,11 +8144,11 @@ msgstr "Transac."
 msgid "Transactions"
 msgstr "Transacciones"
 
-#: src/components/_political/law/law.frontConfig.tsx:408
+#: src/components/_political/law/law.frontConfig.tsx:409
 msgid "Transfer <0/> to <1/>"
-msgstr "Transferir <0/> to <1/>"
+msgstr "Transferir <0/> a <1/>"
 
-#: src/components/_political/law/law.frontConfig.tsx:402
+#: src/components/_political/law/law.frontConfig.tsx:403
 #: src/components/_political/law/lawNames.tsx:28
 msgid "Transfer money"
 msgstr "Transferir dinero"
@@ -8199,21 +8199,21 @@ msgstr "Desequipar todo"
 
 #: src/components/_political/party/party.frontConfig.tsx:415
 msgid "Unethical"
-msgstr "Inmoral"
+msgstr "Antitético"
 
 #: src/components/_political/law/LawEthicEffects.tsx:79
 msgid "Unethical countries cannot hold any treaty — this law cannot be enacted."
-msgstr "Los países que no son éticos no pueden celebrar ningún tratado; esta ley no puede promulgarse."
+msgstr "Los países Antitéticos no pueden mantener ningún tratado; esta ley no puede promulgarse."
 
 #. placeholder {0}: ts.paper
 #: src/components/_military/battle/SetOrderFormModal.tsx:457
 msgid "Unethical: capital occupied, national orders give only the regular bonus but still cost ×2 <0>{0}</0>"
-msgstr "Inmoral: capital ocupado, las órdenes nacionales solo dan la bonificación regular pero aún así cuestan ×2 <0>{0}</0>"
+msgstr "Antitético: con la capital ocupada, las órdenes nacionales solo otorgan la bonificación normal, pero siguen costando ×2 <0>{0}</0>"
 
 #. placeholder {0}: ts.paper
 #: src/components/_military/battle/SetOrderFormModal.tsx:452
 msgid "Unethical: national orders deal ×2 damage but cost ×2 <0>{0}</0>"
-msgstr "Inmoral: capital ocupado, las órdenes nacionales solo dan la bonificación regular pero aún así cuestan ×2 <0>{0}</0>"
+msgstr "Antitético: las órdenes nacionales infligen ×2 daño pero cuestan ×2 <0>{0}</0>"
 
 #: src/pages/region/[regionId]/index.tsx:200
 msgid "Unlinked"
@@ -8269,8 +8269,8 @@ msgstr "Contribuidores del disturbio"
 msgid "Unselect all"
 msgstr "Deseleccionar todo"
 
-#: src/components/_political/law/law.frontConfig.tsx:429
-#: src/components/_political/law/law.frontConfig.tsx:431
+#: src/components/_political/law/law.frontConfig.tsx:430
+#: src/components/_political/law/law.frontConfig.tsx:432
 msgid "Unset the sworn enemy country"
 msgstr "Eliminar el enemigo principal del país"
 
@@ -8360,7 +8360,7 @@ msgstr "Usado para mantener mejoras"
 
 #: src/utils/translations.tsx:127
 msgid "Used to produce ammunition"
-msgstr "Usado para producir Munición"
+msgstr "Usado para producir munición"
 
 #: src/utils/translations.tsx:69
 msgid "Used to produce Bread"
@@ -8380,7 +8380,7 @@ msgstr "Usado para producir Aceite"
 
 #: src/utils/translations.tsx:89
 msgid "Used to produce Paper"
-msgstr "Se utiliza para producir Papel."
+msgstr "Utilizado para producir Papel"
 
 #: src/utils/translations.tsx:115
 msgid "Used to produce Pills"
@@ -8683,11 +8683,11 @@ msgstr "¡Bienvenido a tu economía!"
 #. placeholder {0}: formatPercent( ethicsBonuses.militarism[2].pacificationDefenseBonusPerLevel, )
 #: src/components/_political/party/party.frontConfig.tsx:116
 msgid "When defending a revolt, gain an additional <0>{0}</0> battle bonus per Pacification Center level."
-msgstr "Al defender una revuelta, obtenga una bonificación de batalla adicional <0>{0}</0> por cada nivel del Centro de Pacificación."
+msgstr "Al defender una revuelta, obtienes una bonificación adicional de batalla de <0>{0}</0> por cada nivel del Centro de Pacificación"
 
 #: src/components/_political/party/party.frontConfig.tsx:63
 msgid "When revolting, you copy the enemy's defensive battle bonus from Bunker region upgrades."
-msgstr "Al rebelarte, copias la bonificación de batalla defensiva del enemigo obtenida de las mejoras de la región del búnker."
+msgstr "Al rebelarte, copias la bonificación defensiva de batalla del enemigo procedente de la mejora de regiones Búnker."
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:156
 msgid "When your <0>Health</0> runs out, open this menu to restore it with food."
@@ -8708,7 +8708,7 @@ msgstr "¿Cuál es el motivo de esta ley?"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:36
 msgid "Winter Soldier Pack"
-msgstr "Paquete Soldado de Invierno"
+msgstr "Paquete Soldado del Invierno"
 
 #: src/components/_economy/workOffer/EstimatedCompanyBenefit.tsx:185
 msgid "with bonus"
@@ -8737,11 +8737,11 @@ msgstr "Madera"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:251
 msgid "Wooden Self Bow"
-msgstr "Arco simple de madera"
+msgstr "Arco Largo de Madera"
 
 #: src/components/_other/shop/skin.frontConfig.tsx:254
 msgid "Woolly Mammoth"
-msgstr "Mamut lanudo"
+msgstr "Mamut Lanudo"
 
 #: src/components/_economy/company/WorkButton.tsx:244
 #: src/components/_user/mission/mission.frontConfig.tsx:76
@@ -8998,7 +8998,7 @@ msgstr "¡Dejaste tu trabajo!"
 #. placeholder {0}: gameConfig.election.candidateMinLevel
 #: src/components/_political/election/Election.tsx:133
 msgid "You must be at least level {0} to become a candidate."
-msgstr "Debes tener al menos el nivel {0} para convertirte en candidato."
+msgstr "Debes ser al menos nivel {0} para convertirte en candidato."
 
 #. placeholder {0}: gameConfig.region.resistanceContributionMinLevel
 #. placeholder {0}: gameConfig.unrest.contributionMinLevel
@@ -9010,7 +9010,7 @@ msgstr "Para contribuir, debes ser al menos de nivel {0}."
 #. placeholder {0}: gameConfig.election.voteMinLevel
 #: src/components/_political/election/Election.tsx:226
 msgid "You must be at least level {0} to vote."
-msgstr "Debes tener al menos el nivel {0} para votar."
+msgstr "Debes ser al menos nivel {0} para votar."
 
 #: src/components/_user/premium/PremiumActions.tsx:42
 msgid "You must be on web to subscribe"
@@ -9189,7 +9189,7 @@ msgstr "Tus ancestros están orgullosos"
 
 #: src/components/_political/government/AnnouncementForm.tsx:23
 msgid "Your announcement to the country..."
-msgstr "Su anuncio al país..."
+msgstr "Tu anuncio al país..."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:366
 #: src/components/_user/notification/notification.frontConfig.tsx:1066


### PR DESCRIPTION
This update improves consistency and clarity across diplomacy, alliance, development, ethics, and combat-related texts.

Several descriptions, laws, bonuses, and maintenance cost tooltips were reviewed and standardized to ensure consistent terminology throughout the Spanish translation.

Additionally, the terms "Core Regions" and "Core Development" were translated as "Regiones nacionales" and "Desarrollo nacional". While core literally translates to core, center, or nucleus, those terms sound unnatural in a territorial context in Spanish. The chosen translations better reflect the intended gameplay meaning and are more intuitive for Spanish-speaking players.