### PR TITLE
Update lt/messages.po

### DIFF
--- a/lt/messages.po
+++ b/lt/messages.po
@@ -746,7 +746,7 @@ msgstr "<0>{ethicSpecializationBonus}</0> iš <1/> pramonininko etikos specializ
 
 #: src/components/_economy/company/CompanyProductionBonusTag.tsx:53
 msgid "<0>{strategicBonus}</0> from <1/> strategic resources production bonus."
-msgstr "<0>{strategicBonus}</0> iš strateginių išteklių gamybos bonuso."
+msgstr "<0>{strategicBonus}</0> iš <1/> strateginių išteklių gamybos bonuso."
 
 #: src/pages/country/[countryId]/index.tsx:352
 #: src/pages/country/[countryId]/index.tsx:401
@@ -792,7 +792,7 @@ msgstr "<0>Kas <1/> bendros abiejų pusių padarytos žalos į mūšio fondą pr
 #. placeholder {2}: 10
 #: src/components/_user/worker/WorkerItem.tsx:122
 msgid "<0>Everyday passed working for same employer, the fidelity bonus increases by <1>{0}</1>.</0><2>It increase by <3>{1}</3> the production bonus until <4>{2}</4>.</2><5>This bonus is applied after work. So it is not counted in wage.</5>"
-msgstr "<0>Kiekvieną dieną dirbant tam pačiam darbdaviui, lojalumo bonusas padidėja <1>{0}</1>.</0><2>Ji padidina gamybos bonusą <3>{1}</3> iki <4>{2}</4>.</2><5>Šis bonusas pritaikomas po darbo, todėl į atlyginimą neįskaičiuojama.</5>"
+msgstr "<0>Kiekvieną dieną dirbant tam pačiam darbdaviui, lojalumo bonusas padidėja <1>{0}</1>.</0><2>Jis padidina gamybos bonusą <3>{1}</3> iki <4>{2}</4>.</2><5>Šis bonusas pritaikomas po darbo, todėl į atlyginimą neįskaičiuojama.</5>"
 
 #: src/components/_economy/company/CompanyProduce.tsx:81
 msgid "<0>Filled with <1>Production Points</1> by employees working and from the automated engine.</0><2>Only the company owner can spend it to produce items.</2>"
@@ -7298,7 +7298,7 @@ msgstr "Nustatyti specializacijos daiktą"
 #. placeholder {0}: ts[law.data.itemCode]
 #: src/components/_political/law/law.frontConfig.tsx:596
 msgid "Set the country's specialized item to <0>{0}</0>.<1/>The country strategic resources <2>Production Bonus</2> will be available for local companies producing this item."
-msgstr "Nustatyti šalies specializuotą prekę kaip <0>{0}</0>.<1/>Šalies strateginių išteklių <2>Gamybos bonusas</2> bus taikoma vietinėms įmonėms, gaminančioms šią prekę."
+msgstr "Nustatyti šalies specializuotą prekę kaip <0>{0}</0>.<1/>Šalies strateginių išteklių <2>Gamybos bonusas</2> bus taikomas vietinėms įmonėms, gaminančioms šią prekę."
 
 #: src/components/_political/law/law.frontConfig.tsx:591
 msgid "Set the country's specialized production item"

--- a/lt/messages.po
+++ b/lt/messages.po
@@ -296,11 +296,11 @@ msgstr "<0/> padovanojo tau banerį \"{0}\"!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1745
 msgid "<0/> gifted you the skin \"{skinTitle}\"!"
-msgstr "<0/> padovanojo tau \"{skinTitle}\" skiną!"
+msgstr "<0/> padovanojo tau \"{skinTitle}\" išvaizdą!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1816
 msgid "<0/> gifted you the skin pack \"{skinPackTitle}\"!"
-msgstr "<0/> padovanojo tau išvaizdų rinkinį \"{skinPackTitle}\"!"
+msgstr "<0/> padovanojo tau skinų rinkinį \"{skinPackTitle}\"!"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:227
 msgid "<0/> got fee back"
@@ -675,7 +675,7 @@ msgstr "<0>{0}</0> iš gynybinio pakto su <1/>"
 #. placeholder {0}: region.ethicDepositBonus
 #: src/components/_economy/company/RecommendedCompanyRegions.tsx:134
 msgid "<0>{0}</0> from agrarian ethics deposit bonus."
-msgstr "<0>{0}</0> iš agrarinės etikos depozito bonuso."
+msgstr "<0>{0}</0> iš agrarinės etikos telkinių bonuso."
 
 #. placeholder {0}: region.depositBonus
 #: src/components/_economy/company/RecommendedCompanyRegions.tsx:124
@@ -715,7 +715,7 @@ msgstr "<0>{0}</0> iš strateginių išteklių gamybos bonuso."
 #. placeholder {0}: gameConfig.battle.pointsToWinRound
 #: src/components/_common/RoundPoints.tsx:17
 msgid "<0>{0}</0> ground are required to win a round, points are gained every tick"
-msgstr "Norint laimėti raundą, reikia <0>{0}</0> taškų, kurie gaunami kiekvieną taktą"
+msgstr "Norint laimėti raundą, reikia <0>{0}</0> taškų, kurie gaunami kiekvieną ciklą"
 
 #. placeholder {0}: data.refund
 #: src/components/_user/notification/notification.frontConfig.tsx:1607
@@ -734,11 +734,11 @@ msgstr "<0>{0}</0>/dieną"
 
 #: src/components/_economy/company/CompanyProductionBonusTag.tsx:75
 msgid "<0>{depositBonus}</0> from deposit resources in <1/>."
-msgstr "<0>{depositBonus}</0> iš depozito išteklių <1/>."
+msgstr "<0>{depositBonus}</0> iš telkinių išteklių <1/>."
 
 #: src/components/_economy/company/CompanyProductionBonusTag.tsx:86
 msgid "<0>{ethicDepositBonus}</0> from <1/> agrarian ethics deposit bonus."
-msgstr "<0>{ethicDepositBonus}</0> iš <1/> agrarinės etikos depozito bonuso."
+msgstr "<0>{ethicDepositBonus}</0> iš <1/> agrarinės etikos telkinių bonuso."
 
 #: src/components/_economy/company/CompanyProductionBonusTag.tsx:64
 msgid "<0>{ethicSpecializationBonus}</0> from <1/> industrialist ethics specialization bonus."
@@ -810,7 +810,7 @@ msgstr "<0>Neramumai</0> atspindi vidinę įtampą šalyje.<1/><2/>Piliečiai ga
 
 #: src/components/_user/modals/PhoneVerificationModal.tsx:113
 msgid "<0>Your account requires additional verification. Please verify your phone number as soon as possible to continue using your account normally. Unverified accounts will have restricted access after 48 hours and may be permanently suspended after 5 days.</0><1>Phone numbers are encrypted and not visible to any administrator.</1>"
-msgstr "<0>Jūsų paskyrai reikalingas papildomas patvirtinimas. Kad galėtumėte toliau įprastai naudotis paskyra, kuo greičiau patvirtinkite savo telefono numerį. Nepatvirtintoms paskyroms po 48 valandų bus apribota prieiga, o po 5 dienų jos gali būti visam laikui sustabdytos.</0><1>Telefono numeriai yra šifruojami ir nėra matomi jokiam administratoriui.</1>"
+msgstr "<0>Tavo paskyrai reikalingas papildomas patvirtinimas. Kad galėtum toliau įprastai naudotis paskyra, kuo greičiau patvirtink savo telefono numerį. Nepatvirtintoms paskyroms po 48 valandų bus apribota prieiga, o po 5 dienų jos gali būti visam laikui sustabdytos.</0><1>Telefono numeriai yra šifruojami ir nėra matomi jokiam administratoriui.</1>"
 
 #: src/components/_layout/LayoutOptions.tsx:97
 msgid "= consumes more power"
@@ -862,7 +862,7 @@ msgstr "1★ Kapralas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:82
 msgid "1★ Ensign"
-msgstr "1★ Jaunesnysis leitenantas"
+msgstr "1★ Jaunesnysis Leitenantas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:149
 msgid "1★ General"
@@ -874,7 +874,7 @@ msgstr "1★ Naujokas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:87
 msgid "1★ Lieutenant"
-msgstr "1★ leitenantas"
+msgstr "1★ Leitenantas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:102
 msgid "1★ Lt. Colonel"
@@ -938,7 +938,7 @@ msgstr "1★ Viceadmirolas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:77
 msgid "1★ Warrant Officer"
-msgstr "1★ Vyresnysis Puskarininkis"
+msgstr "1★ Vyresnysis puskarininkis"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:33
 msgid "100% historically accurate"
@@ -1006,7 +1006,7 @@ msgstr "2★ Pulkininkas Leitenantas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:143
 msgid "2★ Lt. General"
-msgstr "2★ Generolas leitenantas"
+msgstr "2★ Generolas Leitenantas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:98
 msgid "2★ Major"
@@ -1669,7 +1669,7 @@ msgstr "Ar tikrai norite pažeminti šį vadą?"
 
 #: src/components/_user/worker/WorkerEditFormModal.tsx:113
 msgid "Are you sure you want to fire this worker?"
-msgstr "Ar tikrai norite atleisti šį darbuotoją?"
+msgstr "Ar tikrai nori atleisti šį darbuotoją?"
 
 #: src/components/_military/mu/MuMemberList.tsx:140
 msgid "Are you sure you want to kick this member?"
@@ -1705,7 +1705,7 @@ msgstr "Ar tikrai norite pašalinti šį skelbimą?"
 
 #: src/components/_user/mission/MissionItem.tsx:105
 msgid "Are you sure you want to reroll this mission? Your current progress will be lost."
-msgstr "Ar tikrai nori perridenti šią misiją? Dabartinė pažanga bus prarasta."
+msgstr "Ar tikrai nori pakeisti šią misiją? Dabartinė pažanga bus prarasta."
 
 #. placeholder {0}: token.name
 #: src/components/_user/apiToken/ApiTokenList.tsx:218
@@ -2239,7 +2239,7 @@ msgstr "Atšaukti"
 
 #: src/components/_military/mercenaryContract/MercenaryContractItem.tsx:77
 msgid "Cancel as gov"
-msgstr "Atšaukti kaip vyriausybei"
+msgstr "Atšaukti vyriausybės vardu"
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:162
 msgid "Cancel at any time"
@@ -2495,7 +2495,7 @@ msgstr "Spustelėkite, kad kandidatuotumėte ir iškart pradėtumėte uždirbti 
 
 #: src/components/_economy/inventory/ConsumeItems.tsx:180
 msgid "Click to consume."
-msgstr "Paspauskite, kad suvartotumėte."
+msgstr "Paspausk, kad suvartotum."
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:100
 msgid "Click to reveal what's inside. You might get something valuable!"
@@ -3233,11 +3233,11 @@ msgstr "Pažemintas iš vado pareigų"
 
 #: src/pages/region/[regionId]/index.tsx:60
 msgid "Deposit"
-msgstr "Depozitas"
+msgstr "Telkinys"
 
 #: src/components/_political/event/EventList.tsx:71
 msgid "Deposit depleted"
-msgstr "Indėlis išseko"
+msgstr "Telkinys išseko"
 
 #: src/components/_political/event/EventList.tsx:70
 msgid "Deposit discovered"
@@ -3250,11 +3250,11 @@ msgstr "<1/> išseko <0>{0}</0> telkinys"
 
 #: src/pages/region/[regionId]/index.tsx:56
 msgid "Deposit resource"
-msgstr "Padėti išteklių"
+msgstr "Telkinio išteklius"
 
 #: src/components/_layout/map.frontConfig.tsx:44
 msgid "Deposit resources"
-msgstr "Depozito resursai"
+msgstr "Išteklių telkiniai"
 
 #: src/components/_economy/company/RecommendedCompanyRegions.tsx:86
 msgid "Deposit will be depleted in"
@@ -3262,7 +3262,7 @@ msgstr "Telkinys išseks po"
 
 #: src/components/_political/party/party.frontConfig.tsx:402
 msgid "Deposits cannot spawn within your borders."
-msgstr "Ištekliai negali atsirasti tavo šalies teritorijoje."
+msgstr "Telkiniai negali atsirasti tavo šalies teritorijoje."
 
 #: src/components/_political/party/PartyDescriptionModal.tsx:62
 #: src/components/_political/party/PartyFormModal.tsx:103
@@ -3289,7 +3289,7 @@ msgstr "Likviduoti"
 
 #: src/components/_layout/map.frontConfig.tsx:38
 msgid "Development"
-msgstr "Plėtra"
+msgstr "Išsivystymas"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:301
 msgid "Diminish <0/> received damages with <1>Armor</1> in battles"
@@ -3572,11 +3572,11 @@ msgstr "Energija"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:81
 msgid "Ensign"
-msgstr "Jaunesnysis leitenantas"
+msgstr "Jaunesnysis Leitenantas"
 
 #: src/components/_political/law/LawFormModal.tsx:245
 msgid "Enter article ID"
-msgstr "Įveskite straipsnio ID"
+msgstr "Įvesk straipsnio ID"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:163
 #: src/components/_user/auth/ConnectFromModal.tsx:168
@@ -3819,7 +3819,7 @@ msgstr "Srautas"
 
 #: src/components/_user/worker/WorkerItem.tsx:120
 msgid "Fidelity Bonus"
-msgstr "Ištikimybės premija"
+msgstr "Lojalumo premija"
 
 #: src/components/_economy/workOffer/EstimatedCompanyBenefit.tsx:164
 msgid "Fidelity bonus:"
@@ -4016,11 +4016,11 @@ msgstr "Pagamina <0>{0}</0> per dieną"
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:50
 msgid "Get an exclusive <0>subscriber skin</0>!"
-msgstr "Gaukite išskirtinę <0>prenumeratoriaus išvaizdą</0>!"
+msgstr "Gaukite išskirtinę <0>prenumeratoriaus skiną</0>!"
 
 #: src/components/_other/shop/SkinCollectionModal.tsx:94
 msgid "Get multiple skins at once with a 30% discount!"
-msgstr "Gaukite kelias išvaizdas vienu metu su 30 % nuolaida!"
+msgstr "Gaukite kelis skinus vienu metu su 30 % nuolaida!"
 
 #: src/components/_economy/inventory/DismantleModal.tsx:221
 msgid "Get supporter plan"
@@ -4203,7 +4203,7 @@ msgstr "Sausuma"
 
 #: src/components/_military/battle/BattleSystem.tsx:673
 msgid "ground per tick"
-msgstr "sausumos taškai per taktą"
+msgstr "sausumos taškai per ciklą"
 
 #: src/components/_military/damageRanking/DamageRankingSides.tsx:123
 msgid "Ground points"
@@ -4946,11 +4946,11 @@ msgstr "Popierinis Meilės Naikintuvas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:101
 msgid "Lt. Colonel"
-msgstr "Pulkininkas leitenantas"
+msgstr "Pulkininkas Leitenantas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:141
 msgid "Lt. General"
-msgstr "Generolas leitenantas"
+msgstr "Generolas Leitenantas"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:59
 msgid "Luck is finally on payroll"
@@ -5740,7 +5740,7 @@ msgstr "Kol kas nėra pakvietusio žaidėjo"
 
 #: src/components/_user/user/UserEquippedSkins.tsx:139
 msgid "No skins equipped"
-msgstr "Nėra užsidėtų išvaizdų"
+msgstr "Nėra užsidėtų skinų"
 
 #: src/components/_political/country/CountryDiplomacyGrid.tsx:326
 msgid "No sworn enemy"
@@ -5874,7 +5874,7 @@ msgstr "Vos vienas žingsnis iki legendinio..."
 #: src/components/_political/party/party.frontConfig.tsx:345
 #: src/components/_political/party/party.frontConfig.tsx:366
 msgid "Only buffs and food deposits spawn in your borders (coca, grain, livestock and fish)."
-msgstr "Tik tavo teritorijoje atsiranda bonusai ir maisto ištekliai (koka, grūdai, gyvuliai ir žuvis)."
+msgstr "Tavo teritorijoje atsiranda tik pastiprinimai ir maisto telkiniai (koka, grūdai, gyvuliai ir žuvis)."
 
 #: src/components/_military/tournament/TournamentRegisterButton.tsx:156
 msgid "Only MU owners/commanders can register their MU"
@@ -6893,7 +6893,7 @@ msgstr "Užklausos:"
 
 #: src/components/_user/mission/MissionItem.tsx:104
 msgid "Reroll Mission"
-msgstr "Permesti misiją"
+msgstr "Pakeisti misiją"
 
 #: src/pages/user/[userId]/skills.tsx:167
 msgid "Reset"
@@ -7166,7 +7166,7 @@ msgstr "Pasirinkite siūlymo tipą"
 
 #: src/components/_user/user/UserDropdown.tsx:262
 msgid "Select skin"
-msgstr "Pasirinkite išvaizdą"
+msgstr "Pasirink skiną"
 
 #: src/components/_economy/work/WorkChart.tsx:224
 #: src/components/_user/mission/mission.frontConfig.tsx:73
@@ -7403,7 +7403,7 @@ msgstr "Gavote skiną dovanų"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1950
 msgid "Skin gift sent"
-msgstr "Išvaizdos dovana išsiųsta"
+msgstr "Skino dovana išsiųsta"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1955
 msgid "Skin pack gift sent"
@@ -7411,21 +7411,21 @@ msgstr "Skinų rinkinio dovana išsiųsta"
 
 #: src/components/_other/shop/SkinPackModal.tsx:85
 msgid "Skin pack unlocked! All skins equipped!"
-msgstr "Atrakintas išvaizdų rinkinys! Visos išvaizdos pritaikytos!"
+msgstr "Atrakintas skinų rinkinys! Visi skinai uždėti!"
 
 #: src/components/_other/shop/SkinCollectionModal.tsx:91
 msgid "Skin Packs"
-msgstr "Išvaizdų paketai"
+msgstr "Skinų paketai"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2126
 msgid "Skin Reward"
-msgstr "Išvaizdos apdovanojimas"
+msgstr "Skino apdovanojimas"
 
 #: src/components/_other/shop/ShopHeader.tsx:22
 #: src/pages/shop/index.tsx:145
 #: src/pages/user/[userId]/index.tsx:93
 msgid "Skins"
-msgstr "Išvaizdos"
+msgstr "Skinai"
 
 #: src/components/_other/shop/SkinPackModal.tsx:250
 msgid "Skins in this pack"
@@ -7696,7 +7696,7 @@ msgstr "Prisiekusio priešo išlaikymo išlaidos padidintos <0>{0}</0>."
 #: src/components/_political/party/party.frontConfig.tsx:141
 #: src/components/_political/party/party.frontConfig.tsx:177
 msgid "Sworn enemy treaties start at <0>{0} fidelity</0> and gain <1>{1}</1> each day."
-msgstr "Prisiekusio priešo sutartys prasideda nuo <0>{0} ištikimybės</0> ir gauna <1>{1}</1> kiekvieną dieną."
+msgstr "Prisiekusio priešo sutartys prasideda nuo <0>{0} lojalumo</0> ir gauna <1>{1}</1> kiekvieną dieną."
 
 #. placeholder {0}: ts.paper
 #: src/components/_military/battle/SetOrderFormModal.tsx:433
@@ -7719,7 +7719,7 @@ msgstr "Perimti valdymą"
 
 #: src/components/_economy/company/RecommendedCompanyRegions.tsx:62
 msgid "Take deposits into account"
-msgstr "Atsižvelgti į indėlius"
+msgstr "Atsižvelgti į telkinius"
 
 #: src/utils/translations.tsx:26
 msgid "Tank"
@@ -7811,7 +7811,7 @@ msgstr "Telkinys suteikia tokio dydžio gamybos bonusą procentais."
 
 #: src/pages/region/[regionId]/index.tsx:80
 msgid "The deposit will expire in the following amount of time."
-msgstr "Indėlis nustos galioti po šio laiko."
+msgstr "Telkinys baigs galioti po nurodyto laiko."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:715
 msgid "The effect of your consumed buffs has ended. The debuff phase has begun and will last <0>{debuffDuration}h</0>."
@@ -8446,7 +8446,7 @@ msgstr "Vartotojas ir progresas"
 
 #: src/components/_other/shop/SkinPackModal.tsx:268
 msgid "User already owns all skins"
-msgstr "Naudotojas jau turi visas išvaizdas"
+msgstr "Naudotojas jau turi visus skinus"
 
 #: src/components/_user/user/UserDropdown.tsx:132
 msgid "User blocked"
@@ -8950,7 +8950,7 @@ msgstr "Už \"{skinTitle}\" pardavimą gavai brangakmenių!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1878
 msgid "You earned gems from a skin pack sale!"
-msgstr "Gavai brangakmenių už apvalkalų rinkinio pardavimą!"
+msgstr "Gavai brangakmenių už skinų rinkinio pardavimą!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:729
 msgid "You feel healthy, the debuff effect no longer affects you."
@@ -9087,7 +9087,7 @@ msgstr "Gavote atlygį už {0} {1} <0/>reitingo <1/> pakopoje"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1896
 msgid "You received the skin \"{skinTitle}\"!"
-msgstr "Gavote išvaizdą \"{skinTitle}\"!"
+msgstr "Gavai \"{skinTitle}\" skiną!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:595
 msgid "You sold items."
@@ -9108,7 +9108,7 @@ msgstr "Sėkmingai padovanojote premium prenumeratą <0/>!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1781
 msgid "You successfully gifted the skin pack \"{skinPackTitle}\" to <0/>!"
-msgstr "Sėkmingai padovanojote išvaizdų rinkinį \"{skinPackTitle}\" žaidėjui <0/>!"
+msgstr "Sėkmingai padovanojai skinų rinkinį \"{skinPackTitle}\" žaidėjui <0/>!"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:130
 msgid "You survived the big reset"

--- a/lt/messages.po
+++ b/lt/messages.po
@@ -90,7 +90,7 @@ msgstr "Reikia {0} aktyvių piliečių"
 #. placeholder {0}: data.userId && ( <UserUsername userId={data.userId} withAvatar withFlag /> )
 #: src/components/_user/notification/notification.frontConfig.tsx:487
 msgid "{0} bought your item offer"
-msgstr "{0} nupirko jūsų prekę"
+msgstr "{0} nupirko tavo prekę"
 
 #. placeholder {0}: Math.floor(cooldownHours / 24)
 #: src/components/_political/partyMotion/PartyMotionTypeSelect.tsx:144
@@ -144,7 +144,7 @@ msgstr "Dirbant šioje įmonėje, nuo uždarbio bus nuskaičiuotas {0}% pajamų 
 #. placeholder {0}: region.taxPercent
 #: src/components/_economy/company/RecommendedCompanyRegions.tsx:151
 msgid "{0}% income tax will be deducted from your workers wages."
-msgstr "Iš jūsų darbuotojų atlyginimų bus išskaičiuotas {0}% pajamų mokestis."
+msgstr "Iš tavo darbuotojų atlyginimų bus išskaičiuotas {0}% pajamų mokestis."
 
 #. placeholder {0}: gameConfig.company.destructionValuePercent
 #: src/components/_economy/company/CompanyDropdown.tsx:321
@@ -225,7 +225,7 @@ msgstr "<0/> perka <1/> už <2>{0}</2>"
 #. placeholder {0}: law.data.amount ?? 0
 #: src/components/_political/law/law.frontConfig.tsx:454
 msgid "<0/> buys your region <1/> for <2>{0}</2>"
-msgstr "<0/> perka jūsų regioną <1/> už <2>{0}</2>"
+msgstr "<0/> perka tavo regioną <1/> už <2>{0}</2>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1594
 msgid "<0/> cancelled the contract."
@@ -233,7 +233,7 @@ msgstr "<0/> atšaukė sutartį."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:773
 msgid "<0/> commented on your article <1/>"
-msgstr "<0/> pakomentavo jūsų straipsnį <1/>"
+msgstr "<0/> pakomentavo tavo straipsnį <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1569
 msgid "<0/> completed a contract, you earned <1/>"
@@ -353,7 +353,7 @@ msgstr "<0/> sudarė aljansą su <1/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:392
 msgid "<0/> has invited your country to join."
-msgstr "<0/> pakvietė jūsų šalį prisijungti."
+msgstr "<0/> pakvietė tavo šalį prisijungti."
 
 #: src/components/_political/event/event.frontConfig.tsx:349
 msgid "<0/> has joined the alliance <1/>"
@@ -398,7 +398,7 @@ msgstr "<0/> puola <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:894
 msgid "<0/> is attacking your country in <1/>"
-msgstr "<0/> puola jūsų šalį teritorijoje <1/>"
+msgstr "<0/> puola tavo šalį teritorijoje <1/>"
 
 #: src/components/_political/event/event.frontConfig.tsx:304
 msgid "<0/> is in bankruptcy. Removing all alliances and disabling every region upgrades."
@@ -423,7 +423,7 @@ msgstr "<0/> prisijungė prie žaidimo per tavo pakvietimo nuorodą!"
 #. placeholder {0}: data.wage
 #: src/components/_user/notification/notification.frontConfig.tsx:411
 msgid "<0/> joined your company <1/> for <2>{0}</2> wage"
-msgstr "<0/> įsidarbino jūsų įmonėje <1/> už <2>{0}</2> atlyginimą"
+msgstr "<0/> įsidarbino tavo įmonėje <1/> už <2>{0}</2> atlyginimą"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:43
 msgid "<0/> kicked <1/> from the conversation"
@@ -432,7 +432,7 @@ msgstr "<0/> pašalino <1/> iš pokalbio"
 #. placeholder {0}: data.company && <CompanyNameById companyId={data.company} />
 #: src/components/_user/notification/notification.frontConfig.tsx:427
 msgid "<0/> left his job in your company {0}"
-msgstr "<0/> paliko darbą jūsų įmonėje {0}"
+msgstr "<0/> paliko darbą tavo įmonėje {0}"
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:34
 msgid "<0/> left the conversation"
@@ -472,7 +472,7 @@ msgstr "<0/> Prioritetas baigsis po <1/>"
 
 #: src/components/_political/law/law.frontConfig.tsx:296
 msgid "<0/> proposed a mutual defensive pact to your country."
-msgstr "<0/> pasiūlė jūsų šaliai abipusį gynybinį paktą."
+msgstr "<0/> pasiūlė tavo šaliai abipusį gynybinį paktą."
 
 #: src/components/_political/message/systemMessage.frontConfig.tsx:145
 msgid "<0/> proposed a new alliance law: <1/>"
@@ -498,7 +498,7 @@ msgstr "<0/> pakvietė jus į žaidimą."
 #. placeholder {0}: data.messageId && <MessageItemById messageId={data.messageId} />
 #: src/components/_user/notification/notification.frontConfig.tsx:866
 msgid "<0/> responded to your message {0}"
-msgstr "<0/> atsakė į jūsų žinutę {0}"
+msgstr "<0/> atsakė į tavo žinutę {0}"
 
 #. placeholder {0}: data.messageId && <MessageItemById messageId={data.messageId} />
 #: src/components/_user/notification/notification.frontConfig.tsx:857
@@ -531,7 +531,7 @@ msgstr "<0/> nori taikos"
 
 #: src/components/_political/law/law.frontConfig.tsx:104
 msgid "<0/> wants to make peace with your country"
-msgstr "<0/> nori sudaryti taiką su jūsų šalimi"
+msgstr "<0/> nori sudaryti taiką su tavo šalimi"
 
 #: src/components/_political/event/event.frontConfig.tsx:197
 msgid "<0/> was elected president of <1/>"
@@ -1122,11 +1122,11 @@ msgstr "3★ Leitenantas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:104
 msgid "3★ Lt. Colonel"
-msgstr "3★ Pulkininkas leitenantas"
+msgstr "3★ Pulkininkas Leitenantas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:144
 msgid "3★ Lt. General"
-msgstr "3★ Generolas leitenantas"
+msgstr "3★ Generolas Leitenantas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:99
 msgid "3★ Major"
@@ -1198,7 +1198,7 @@ msgstr "4★ Generolas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:145
 msgid "4★ Lt. General"
-msgstr "4★ Generolas leitenantas"
+msgstr "4★ Generolas Leitenantas"
 
 #: src/components/_common/GameRules.tsx:108
 msgid "5. Boosting and Exploitation"
@@ -1214,7 +1214,7 @@ msgstr "5★ Generolas"
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:146
 msgid "5★ Lt. General"
-msgstr "5★ generolas leitenantas"
+msgstr "5★ Generolas Leitenantas"
 
 #: src/components/_common/GameRules.tsx:163
 msgid "6. Taking Over and Misuse of State/Military unit assets"
@@ -1250,7 +1250,7 @@ msgstr "<2/> aptiktas <0>{0}</0> <1>{1}</1> telkinys {2} dienoms"
 #. placeholder {0}: contract.acceptanceFee
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:97
 msgid "A fee of <0>{0}</0> is required to accept this contract. The fee is returned once you complete the minimum damage of <1/>. If you fail to complete the contract or the country cancels it, the fee is lost."
-msgstr "Norint priimti šią sutartį, reikalingas <0>{0}</0> mokestis. Mokestis grąžinamas, kai padarote minimalią žalą <1/>. Jei neįvykdysite sutarties arba šalis ją atšauks, mokestis bus prarastas."
+msgstr "Norint priimti šią sutartį, reikalingas <0>{0}</0> mokestis. Mokestis grąžinamas, kai padarai minimalią žalą <1/>. Jei neįvykdysi sutarties arba šalis ją atšauks, mokestis bus prarastas."
 
 #. placeholder {0}: contract.acceptanceFee
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:91
@@ -1314,7 +1314,7 @@ msgstr "Priimti taiką"
 
 #: src/components/_political/law/law.frontConfig.tsx:90
 msgid "Accept to make peace with the other country"
-msgstr "Sutikite sudaryti taiką su kita šalimi"
+msgstr "Sutik sudaryti taiką su kita šalimi"
 
 #: src/components/_political/law/GenericLawStatus.tsx:40
 msgid "Accepted"
@@ -1476,7 +1476,7 @@ msgstr "Visi raundai"
 
 #: src/components/_other/shop/SkinPackModal.tsx:270
 msgid "All skins owned"
-msgstr "Turite visus skinus"
+msgstr "Turi visus skinus"
 
 #: src/components/_common/GameRules.tsx:59
 msgid "All transactions must stay fair and balanced."
@@ -1567,11 +1567,11 @@ msgstr "Kiek <0>gamybos taškų</0> galima laikyti įmonėje, kol gamyba sustos.
 
 #: src/components/_user/user/skills.frontConfig.tsx:186
 msgid "Amount of <0>Workers</0> you can manage. And daily hire limit."
-msgstr "Kiek <0>darbuotojų</0> galite valdyti ir koks yra dienos samdymo limitas."
+msgstr "Kiek <0>darbuotojų</0> gali valdyti ir koks yra dienos samdymo limitas."
 
 #: src/components/_user/user/skills.frontConfig.tsx:109
 msgid "Amount of companies you can own"
-msgstr "Įmonių, kurias galite turėti, skaičius"
+msgstr "Įmonių, kurias gali turėti, skaičius"
 
 #. placeholder {0}: data.refund
 #: src/components/_user/notification/notification.frontConfig.tsx:1587
@@ -1588,7 +1588,7 @@ msgstr "Sukurta sąjunga"
 
 #: src/components/_political/law/law.frontConfig.tsx:379
 msgid "An alliance has invited your country to join"
-msgstr "Aljansas pakvietė jūsų šalį prisijungti"
+msgstr "Aljansas pakvietė tavo šalį prisijungti"
 
 #: src/components/_political/alliance/AllianceBattleBonus.tsx:46
 msgid "An alliance's battle <0>damage</0> bonus depends on its share of the world's total <1>Development</1>."
@@ -1608,7 +1608,7 @@ msgstr "Skelbimas"
 
 #: src/components/_political/law/law.frontConfig.tsx:282
 msgid "Another country proposed a defensive pact to yours"
-msgstr "Kita šalis pasiūlė jūsų šaliai gynybinį paktą"
+msgstr "Kita šalis pasiūlė tavo šaliai gynybinį paktą"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:40
 msgid "Anti Terrorist Pack"
@@ -1636,7 +1636,7 @@ msgstr "API raktai"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:101
 msgid "API tokens allow external applications to access the API on your behalf. Use the token in the <0>X-API-Key</0> header. Each token has a rate limit of 200 requests per minute."
-msgstr "API raktai leidžia išorinėms programoms pasiekti API jūsų vardu. Naudokite žetoną <0>X-API-Key</0> antraštėje. Kiekvienam žetonui taikomas 200 užklausų per minutę limitas."
+msgstr "API raktai leidžia išorinėms programoms pasiekti API tavo vardu. Naudok žetoną <0>X-API-Key</0> antraštėje. Kiekvienam žetonui taikomas 200 užklausų per minutę limitas."
 
 #: src/components/_layout/LayoutOptions.tsx:257
 msgid "App pattern"
@@ -1661,11 +1661,11 @@ msgstr "Arcane Batai"
 
 #: src/components/_economy/inventory/ConsumeItems.tsx:236
 msgid "Are you sure you want to consume pill?"
-msgstr "Ar tikrai norite suvartoti piliulę?"
+msgstr "Ar tikrai nori suvartoti piliulę?"
 
 #: src/components/_military/mu/MuMemberList.tsx:154
 msgid "Are you sure you want to demote this commander?"
-msgstr "Ar tikrai norite pažeminti šį vadą?"
+msgstr "Ar tikrai nori pažeminti šį vadą?"
 
 #: src/components/_user/worker/WorkerEditFormModal.tsx:113
 msgid "Are you sure you want to fire this worker?"
@@ -1673,7 +1673,7 @@ msgstr "Ar tikrai nori atleisti šį darbuotoją?"
 
 #: src/components/_military/mu/MuMemberList.tsx:140
 msgid "Are you sure you want to kick this member?"
-msgstr "Ar tikrai norite pašalinti šį narį?"
+msgstr "Ar tikrai nori pašalinti šį narį?"
 
 #: src/pages/country/[countryId]/government.tsx:112
 msgid "Are you sure you want to leave the congress?"
@@ -1685,15 +1685,15 @@ msgstr "Ar tikrai nori pasitraukti iš vyriausybės?"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:138
 msgid "Are you sure you want to place this bid?"
-msgstr "Ar tikrai norite pateikti šį statymą?"
+msgstr "Ar tikrai nori pateikti šį statymą?"
 
 #: src/components/_military/mu/MuMemberList.tsx:147
 msgid "Are you sure you want to promote this member to commander?"
-msgstr "Ar tikrai norite paaukštinti šį narį į vadą?"
+msgstr "Ar tikrai nori paaukštinti šį narį į vadą?"
 
 #: src/pages/market/index.tsx:196
 msgid "Are you sure you want to remove all buy orders?"
-msgstr "Ar tikrai norite pašalinti visus pirkimo užsakymus?"
+msgstr "Ar tikrai nori pašalinti visus pirkimo užsakymus?"
 
 #: src/pages/market/index.tsx:259
 msgid "Are you sure you want to remove all sell orders?"
@@ -1701,7 +1701,7 @@ msgstr "Ar tikrai nori pašalinti visus pardavimo pasiūlymus?"
 
 #: src/pages/country/[countryId]/government.tsx:165
 msgid "Are you sure you want to remove this announcement?"
-msgstr "Ar tikrai norite pašalinti šį skelbimą?"
+msgstr "Ar tikrai nori pašalinti šį skelbimą?"
 
 #: src/components/_user/mission/MissionItem.tsx:105
 msgid "Are you sure you want to reroll this mission? Your current progress will be lost."
@@ -1710,15 +1710,15 @@ msgstr "Ar tikrai nori pakeisti šią misiją? Dabartinė pažanga bus prarasta.
 #. placeholder {0}: token.name
 #: src/components/_user/apiToken/ApiTokenList.tsx:218
 msgid "Are you sure you want to revoke \"{0}\"? This action cannot be undone."
-msgstr "Ar tikrai norite panaikinti \"{0}\"? Šio veiksmo atšaukti negalėsite."
+msgstr "Ar tikrai nori panaikinti \"{0}\"? Šio veiksmo atšaukti negalėsi."
 
 #: src/components/_other/tour/TutorialStep.tsx:186
 msgid "Are you sure you want to skip this tutorial?"
-msgstr "Ar tikrai norite praleisti šią pamoką?"
+msgstr "Ar tikrai nori praleisti šią pamoką?"
 
 #: src/components/_military/mu/MuMemberList.tsx:162
 msgid "Are you sure you want to transfer ownership to this member? This action cannot be undone."
-msgstr "Ar tikrai norite perduoti nuosavybę šiam nariui? Šio veiksmo atšaukti negalima."
+msgstr "Ar tikrai nori perduoti nuosavybę šiam nariui? Šio veiksmo atšaukti negalima."
 
 #: src/components/_user/user/skills.frontConfig.tsx:71
 #: src/components/_user/user/skills.frontConfig.tsx:72
@@ -1850,7 +1850,7 @@ msgstr "Aukcionai"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:141
 msgid "Authentication failed. Please try again."
-msgstr "Nepavyko patvirtinti tapatybės. Bandykite dar kartą."
+msgstr "Nepavyko patvirtinti tapatybės. Bandyk dar kartą."
 
 #: src/pages/country/[countryId]/citizenship.tsx:47
 msgid "Auto approval"
@@ -2210,12 +2210,12 @@ msgstr "Pirkimo užsakymai"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:359
 msgid "By continuing, you agree to our <0>Terms of Service</0>."
-msgstr "Tęsdami sutinkate su mūsų <0>Paslaugų teikimo sąlygomis</0>."
+msgstr "Tęsdamas sutinki su mūsų <0>Paslaugų teikimo sąlygomis</0>."
 
 #. placeholder {0}: worker.fidelity ?? 0
 #: src/components/_user/worker/WageReductionAlert.tsx:56
 msgid "By rejecting the wage reduction, you will leave the company and lose your fidelity bonus of +{0}%."
-msgstr "Atmetę atlyginimo sumažinimą, paliksite įmonę ir prarasite savo lojalumo premiją +{0}%."
+msgstr "Atmetęs atlyginimo sumažinimą, paliksi įmonę ir prarasi savo lojalumo premiją +{0}%."
 
 #: src/components/_military/damageRanking/DamageRankingSides.tsx:150
 msgid "By side"
@@ -2243,7 +2243,7 @@ msgstr "Atšaukti vyriausybės vardu"
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:162
 msgid "Cancel at any time"
-msgstr "Galite bet kada atsisakyti prenumeratos"
+msgstr "Gali bet kada atsisakyti prenumeratos"
 
 #: src/components/_military/mercenaryContract/AdminDeleteContractModal.tsx:43
 #: src/components/_military/mercenaryContract/AdminDeleteContractModal.tsx:64
@@ -2291,7 +2291,7 @@ msgstr "Negali turėti prisiekusių priešų."
 
 #: src/components/_political/party/party.frontConfig.tsx:349
 msgid "Cannot pick a specialization good / no benefit from specialization."
-msgstr "Negalite pasirinkti specializacijos prekės / iš specializacijos negaunate naudos."
+msgstr "Negali pasirinkti specializacijos prekės / iš specializacijos negauni naudos."
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:91
 msgid "Captain"
@@ -2299,7 +2299,7 @@ msgstr "Kapitonas"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:262
 msgid "CAPTCHA challenge expired. Please try again."
-msgstr "CAPTCHA patikros laikas baigėsi. Bandykite dar kartą."
+msgstr "CAPTCHA patikros laikas baigėsi. Bandyk dar kartą."
 
 #: src/components/_user/auth/ConnectFromModal.tsx:258
 msgid "CAPTCHA challenge failed. Resetting..."
@@ -2395,7 +2395,7 @@ msgstr "Pakeisti šalies spalvų schemą"
 #. placeholder {1}: law.data.mapAccent
 #: src/components/_political/law/law.frontConfig.tsx:551
 msgid "Change the country color scheme to <0>{0}</0> with a <1>{1}</1> map accent"
-msgstr "Pakeiskite šalies spalvų schemą į <0>{0}</0> su <1>{1}</1> žemėlapio akcentu"
+msgstr "Pakeisk šalies spalvų schemą į <0>{0}</0> su <1>{1}</1> žemėlapio akcentu"
 
 #: src/components/_political/allianceLaw/allianceLaw.frontConfig.tsx:121
 msgid "Change the name of the alliance."
@@ -2491,7 +2491,7 @@ msgstr "Spustelėk savo šalies pokalbį, kad galėtum bendrauti su kitais pilie
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:67
 msgid "Click to apply and start earning money right away."
-msgstr "Spustelėkite, kad kandidatuotumėte ir iškart pradėtumėte uždirbti pinigus."
+msgstr "Spustelėk, kad kandidatuotum ir iškart pradėtum uždirbti pinigus."
 
 #: src/components/_economy/inventory/ConsumeItems.tsx:180
 msgid "Click to consume."
@@ -2504,11 +2504,11 @@ msgstr "Spustelėk, kad pamatytum, kas viduje. Gali gauti ką nors vertingo!"
 #: src/components/_political/allianceLaw/AllianceLawTypeSelect.tsx:41
 #: src/components/_political/law/LawTypeSelect.tsx:60
 msgid "Click to select law"
-msgstr "Spustelėkite, kad pasirinktumėte įstatymą"
+msgstr "Spustelėk, kad pasirinktum įstatymą"
 
 #: src/components/_political/partyMotion/PartyMotionTypeSelect.tsx:50
 msgid "Click to select motion"
-msgstr "Spustelėkite, kad pasirinktumėte pasiūlymą"
+msgstr "Spustelėk, kad pasirinktum pasiūlymą"
 
 #: src/components/_layout/map.frontConfig.tsx:62
 msgid "Climate"
@@ -2630,34 +2630,34 @@ msgstr "Sveikiname, pasiekei {0} lygį!"
 #. placeholder {0}: data.countryName
 #: src/components/_user/notification/notification.frontConfig.tsx:200
 msgid "Congratulations! You have been elected as the new congress member of {0}"
-msgstr "Sveikiname! Buvote išrinktas naujuoju {0} kongreso nariu"
+msgstr "Sveikiname! Buvai išrinktas naujuoju {0} kongreso nariu"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:304
 msgid "Congratulations! You have been elected as the new leader of <0/>"
-msgstr "Sveikiname! Buvote išrinktas naujuoju <0/> vadovu"
+msgstr "Sveikiname! Buvai išrinktas naujuoju <0/> vadovu"
 
 #. placeholder {0}: data.countryName
 #: src/components/_user/notification/notification.frontConfig.tsx:195
 msgid "Congratulations! You have been elected as the new president of {0}"
-msgstr "Sveikiname! Buvote išrinktas naujuoju {0} prezidentu."
+msgstr "Sveikiname! Buvai išrinktas naujuoju {0} prezidentu."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:309
 msgid "Congratulations! You have been elected to the council of <0/>"
-msgstr "Sveikiname! Buvote išrinktas į <0/> tarybą"
+msgstr "Sveikiname! Buvai išrinktas į <0/> tarybą"
 
 #. placeholder {0}: militaryRankingConfig[data.rank].percentDamages
 #: src/components/_user/notification/notification.frontConfig.tsx:1244
 msgid "Congratulations! You have been promoted to <0/> with an attack bonus of <1>{0}</1>"
-msgstr "Sveikiname! Jūs paaukštintas į <0/>, suteikiant <1>{0}</1> puolimo bonusą"
+msgstr "Sveikiname! Buvai paaukštintas į <0/>, suteikiant <1>{0}</1> puolimo bonusą"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1433
 msgid "Congratulations! You won the giveaway and received cases!"
-msgstr "Sveikiname! Laimėjote loteriją ir gavote dėžių!"
+msgstr "Sveikiname! Laimėjai loteriją ir gavai dėžių!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:353
 #: src/components/_user/notification/notification.frontConfig.tsx:1080
 msgid "Congratulations! Your application to <0/> has been accepted"
-msgstr "Sveikiname! Jūsų paraiška į <0/> buvo priimta"
+msgstr "Sveikiname! Tavo paraiška į <0/> buvo priimta"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1312
 msgid "Congratulations! Your team <0/> won the tournament <1/>!"
@@ -2713,7 +2713,7 @@ msgstr "Užkariautojas"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:69
 msgid "Consider giving it to your local moderator"
-msgstr "Apsvarstykite galimybę atiduoti tai savo vietos moderatoriui"
+msgstr "Apsvarstyk galimybę atiduoti tai savo vietos moderatoriui"
 
 #: src/components/_economy/inventory/ConsumeItems.tsx:177
 msgid "Consume items"
@@ -2784,7 +2784,7 @@ msgstr "Kopijuoti"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:125
 msgid "Copy this token now. You won't be able to see it again! Use it in the <0>X-API-Key</0> header."
-msgstr "Nukopijuokite šį raktą dabar. Vėliau jo nebematysite! Naudokite jį <0>X-API-Key</0> antraštėje."
+msgstr "Nukopijuok šį raktą dabar. Vėliau jo nebematysi! Naudok jį <0>X-API-Key</0> antraštėje."
 
 #: src/components/_political/alliance/AllianceHeader.tsx:90
 #: src/components/_political/government/Government.tsx:206
@@ -2809,7 +2809,7 @@ msgstr "Šalinamas tarybos narys"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:41
 msgid "Counter-strike the enemy"
-msgstr "Duokite atsakomąjį smūgį priešui"
+msgstr "Duok atsakomąjį smūgį priešui"
 
 #: src/components/_layout/LoadingScreenContent.tsx:19
 msgid "countries"
@@ -3079,11 +3079,11 @@ msgstr "Įvykdyk <0>{count}</0> sandorių pagal šalies / karinio vieneto užsak
 
 #: src/components/_user/user/MilitaryRanksInfoModal.tsx:94
 msgid "Deal damage in battles to increase your military rank and unlock attack bonuses."
-msgstr "Darykite žalą mūšiuose, kad keltumėte savo karinį rangą ir atrakintumėte puolimo bonusus."
+msgstr "Daryk žalą mūšiuose, kad keltum savo karinį rangą ir atrakintum puolimo bonusus."
 
 #: src/components/_military/mu/MuLevelsInfoModal.tsx:118
 msgid "Deal damage in battles with your MU members to level up each month and earn rewards. Resets on the 1st of each month."
-msgstr "Kaupkite žalą mūšiuose kartu su savo KM nariais, kad kas mėnesį keltumėte lygį ir gautumėte apdovanojimų. Pažanga atnaujinama kiekvieno mėnesio 1 d."
+msgstr "Kaupk žalą mūšiuose kartu su savo MU nariais, kad kas mėnesį keltum lygį ir gautum apdovanojimų. Pažanga atnaujinama kiekvieno mėnesio 1 d."
 
 #: src/components/_user/mission/mission.frontConfig.tsx:111
 msgid "Deal Damages"
@@ -3187,7 +3187,7 @@ msgstr "Pasirašytas gynybinis paktas"
 #. placeholder {0}: ts.paper
 #: src/components/_military/battle/SetOrderFormModal.tsx:427
 msgid "Defensive pact: orders supporting your pact partner cost {orderDiscountPercent}% less <0>{0}</0>"
-msgstr "Gynybinis paktas: įsakymai, remiantys jūsų pakto partnerį, kainuoja {orderDiscountPercent}% mažiau <0>{0}</0>"
+msgstr "Gynybinis paktas: įsakymai, remiantys tavo pakto partnerį, kainuoja {orderDiscountPercent}% mažiau <0>{0}</0>"
 
 #: src/components/_political/law/law.frontConfig.tsx:228
 msgid "Define <0/> as an enemy, increasing damages when fighting them"
@@ -3199,7 +3199,7 @@ msgstr "Paskelbti <0/> priešu"
 
 #: src/components/_political/law/law.frontConfig.tsx:214
 msgid "Define a country as an enemy to get bonus against"
-msgstr "Paskelbkite šalį priešu, kad gautumėte bonusą prieš ją"
+msgstr "Paskelbk šalį priešu, kad gautum bonusą prieš ją"
 
 #: src/components/_political/law/law.frontConfig.tsx:213
 #: src/components/_political/law/lawNames.tsx:24
@@ -3267,7 +3267,7 @@ msgstr "Telkiniai negali atsirasti tavo šalies teritorijoje."
 #: src/components/_political/party/PartyDescriptionModal.tsx:62
 #: src/components/_political/party/PartyFormModal.tsx:103
 msgid "Describe your party's goals and values"
-msgstr "Aprašykite savo partijos tikslus ir vertybes"
+msgstr "Aprašyk savo partijos tikslus ir vertybes"
 
 #: src/components/_political/party/PartyDescriptionModal.tsx:61
 #: src/components/_political/party/PartyFormModal.tsx:104
@@ -3375,7 +3375,7 @@ msgstr "Nepamiršk išgerti vandens"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:125
 msgid "Don't forget to save your skill upgrades."
-msgstr "Nepamirškite išsaugoti savo įgūdžių patobulinimų."
+msgstr "Nepamiršk išsaugoti savo įgūdžių patobulinimų."
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:13
 msgid "Don't quit now, your luck is buffering"
@@ -3581,7 +3581,7 @@ msgstr "Įvesk straipsnio ID"
 #: src/components/_user/auth/ConnectFromModal.tsx:163
 #: src/components/_user/auth/ConnectFromModal.tsx:168
 msgid "Enter the code we sent to your email."
-msgstr "Įveskite kodą, kurį išsiuntėme į jūsų el. paštą."
+msgstr "Įvesk kodą, kurį išsiuntėme į tavo el. paštą."
 
 #: src/components/_user/user/skills.frontConfig.tsx:179
 #: src/components/_user/user/skills.frontConfig.tsx:180
@@ -3701,7 +3701,7 @@ msgstr "Nepavyko pradėti prisijungimo per Discord."
 
 #: src/components/_user/auth/ConnectFromModal.tsx:104
 msgid "Failed to start Discord login. Please retry the CAPTCHA."
-msgstr "Nepavyko pradėti prisijungimo per Discord. Pakartokite CAPTCHA."
+msgstr "Nepavyko pradėti prisijungimo per Discord. Pakartok CAPTCHA."
 
 #: src/components/_user/auth/ConnectFromModal.tsx:126
 msgid "Failed to start Google login."
@@ -3709,7 +3709,7 @@ msgstr "Nepavyko pradėti prisijungimo per Google."
 
 #: src/components/_user/auth/ConnectFromModal.tsx:124
 msgid "Failed to start Google login. Please retry the CAPTCHA."
-msgstr "Nepavyko pradėti prisijungimo per Google. Bandykite iš naujo įvykdyti CAPTCHA."
+msgstr "Nepavyko pradėti prisijungimo per Google. Bandyk iš naujo įvykdyti CAPTCHA."
 
 #: src/components/_user/user/FamilyGroup.tsx:49
 msgid "Family Group"
@@ -3859,7 +3859,7 @@ msgstr "Finansuoti pasipriešinimo mūšį vietovėje <0/>"
 
 #: src/components/_political/partyMotion/partyMotion.frontConfig.tsx:123
 msgid "Finance a resistance battle in an occupied region of your country"
-msgstr "Finansuokite pasipriešinimo mūšį okupuotame jūsų šalies regione"
+msgstr "Finansuok pasipriešinimo mūšį okupuotame tavo šalies regione"
 
 #: src/components/_political/law/law.frontConfig.tsx:614
 msgid "Finance a resistance to liberate an occupied region"
@@ -3951,7 +3951,7 @@ msgstr "įmonėms, gaminančioms <0>{0}</0> ir įsikūrusioms <1/>."
 
 #: src/components/_political/law/law.frontConfig.tsx:333
 msgid "Found a new alliance with your country as founding member"
-msgstr "Įkurti naują aljansą, kuriame jūsų šalis bus narė steigėja"
+msgstr "Įkurti naują aljansą, kuriame tavo šalis bus narė steigėja"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:45
 msgid "Founding Father"
@@ -4016,11 +4016,11 @@ msgstr "Pagamina <0>{0}</0> per dieną"
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:50
 msgid "Get an exclusive <0>subscriber skin</0>!"
-msgstr "Gaukite išskirtinę <0>prenumeratoriaus skiną</0>!"
+msgstr "Gauk išskirtinę <0>prenumeratoriaus skiną</0>!"
 
 #: src/components/_other/shop/SkinCollectionModal.tsx:94
 msgid "Get multiple skins at once with a 30% discount!"
-msgstr "Gaukite kelis skinus vienu metu su 30 % nuolaida!"
+msgstr "Gauk kelis skinus vienu metu su 30 % nuolaida!"
 
 #: src/components/_economy/inventory/DismantleModal.tsx:221
 msgid "Get supporter plan"
@@ -4056,7 +4056,7 @@ msgstr "Perduoti nuosavybę"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:251
 msgid "Give your token a descriptive name so you can identify it later."
-msgstr "Suteikite prieigos raktui aiškų pavadinimą, kad vėliau galėtumėte jį atpažinti."
+msgstr "Suteik prieigos raktui aiškų pavadinimą, kad vėliau galėtum jį atpažinti."
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:193
 msgid "Giveaway Winner"
@@ -4361,7 +4361,7 @@ msgstr "Didžiuojuosi tavimi"
 
 #: src/components/_military/mercenaryContract/MercenaryReputationTooltip.tsx:39
 msgid "If negative, pay <0/> for <1/> (once per day)."
-msgstr "Jei neigiama, mokėkite <0/> už <1/> (kartą per dieną)."
+msgstr "Jei neigiama, mokėk <0/> už <1/> (kartą per dieną)."
 
 #: src/components/_political/government/NominateForm.tsx:58
 msgid "If the new nominee is already in government, their positions will be swapped. Otherwise the current member will be fired and won't be able to be nominated again for {cooldownDays} days."
@@ -4369,7 +4369,7 @@ msgstr "Jei naujasis kandidatas jau yra vyriausybėje, jų pareigos bus sukeisto
 
 #: src/components/_political/party/party.frontConfig.tsx:429
 msgid "If your capital is occupied, national orders give only the regular bonus and the capital automatically revolts at full resistance."
-msgstr "Jei jūsų sostinė yra okupuota, nacionaliniai įsakymai suteikia tik įprastą bonusą, o sostinėje automatiškai kyla sukilimas su visu pasipriešinimu."
+msgstr "Jei tavo sostinė yra okupuota, nacionaliniai įsakymai suteikia tik įprastą bonusą, o sostinėje automatiškai kyla sukilimas su visu pasipriešinimu."
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:51
 msgid "Imagine if you stop right before the Mythic"
@@ -4609,7 +4609,7 @@ msgstr "Įsidarbino"
 
 #: src/components/_economy/workOffer/WorkOfferList.tsx:133
 msgid "Joining a new job will make you leave your current one!"
-msgstr "Įsidarbinę naujame darbe paliksite dabartinį!"
+msgstr "Įsidarbinęs naujame darbe paliksi dabartinį!"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:22
 msgid "Just 1 more..."
@@ -4617,7 +4617,7 @@ msgstr "Dar tik 1..."
 
 #: src/components/_common/GameRules.tsx:274
 msgid "Just because something isn't explicitly stated in the rules does not mean you can abuse it. Attempts to bypass rules or exploit loopholes will still be punished."
-msgstr "Tai, kad kažkas nėra aiškiai nurodyta taisyklėse, nereiškia, kad galite tuo piktnaudžiauti. Bandymai apeiti taisykles ar pasinaudoti spragomis vis tiek bus baudžiami."
+msgstr "Tai, kad kažkas nėra aiškiai nurodyta taisyklėse, nereiškia, kad gali tuo piktnaudžiauti. Bandymai apeiti taisykles ar pasinaudoti spragomis vis tiek bus baudžiami."
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:50
 msgid "Just one more… what could go wrong?"
@@ -4773,7 +4773,7 @@ msgstr "Palikti vyriausybę"
 
 #: src/components/_political/law/law.frontConfig.tsx:354
 msgid "Leave the alliance your country belongs to"
-msgstr "Palikti aljansą, kuriam priklauso jūsų šalis"
+msgstr "Palikti aljansą, kuriam priklauso tavo šalis"
 
 #: src/components/_political/alliance/AllianceHeader.tsx:80
 msgid "Led by <0/>."
@@ -5098,7 +5098,7 @@ msgstr "Šalys narės"
 
 #: src/components/_political/allianceLaw/AllianceLawFormModal.tsx:153
 msgid "Member country to kick"
-msgstr "Šalis narė, kurią norite pašalinti"
+msgstr "Šalis narė, kurią nori pašalinti"
 
 #: src/components/_military/mu/MuMemberList.tsx:116
 msgid "Member demoted from commander"
@@ -5620,7 +5620,7 @@ msgstr "Nėra aljanso bonuso: sąjungininkų šalies narystė sustabdyta dėl ne
 
 #: src/components/_military/battle/BattleDamageBonuses.tsx:96
 msgid "No alliance bonus: your country's membership is suspended for unpaid alliance maintenance."
-msgstr "Nėra aljanso bonuso: jūsų šalies narystė sustabdyta dėl nesumokėto aljanso išlaikymo."
+msgstr "Nėra aljanso bonuso: tavo šalies narystė sustabdyta dėl nesumokėto aljanso išlaikymo."
 
 #: src/components/_political/allianceLaw/AllianceLawList.tsx:50
 msgid "No alliance laws yet"
@@ -5628,7 +5628,7 @@ msgstr "Aljanso įstatymų dar nėra"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:231
 msgid "No API tokens yet. Create one to get started."
-msgstr "API prieigos raktų dar nėra. Sukurkite vieną, kad galėtumėte pradėti."
+msgstr "API prieigos raktų dar nėra. Sukurki vieną, kad galėtum pradėti."
 
 #: src/components/_user/auth/ConnectFromModal.tsx:140
 msgid "No authorization code provided."
@@ -5894,7 +5894,7 @@ msgstr "Tik savininkas ir vadai gali pakeisti pilietybę."
 
 #: src/components/_political/party/party.frontConfig.tsx:264
 msgid "Only your core regions generate development income."
-msgstr "Tik jūsų pagrindiniai regionai generuoja išsivystymo pajamas."
+msgstr "Tik tavo pagrindiniai regionai generuoja išsivystymo pajamas."
 
 #: src/components/_economy/inventory/case/OpenCaseModal.tsx:524
 msgid "Open"
@@ -5939,7 +5939,7 @@ msgstr "Vienu metu atidaryk kelias <0>dėžes</0>"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:373
 msgid "Open the chat"
-msgstr "Atidarykite pokalbį"
+msgstr "Atidaryk pokalbį"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:216
 msgid "Open to all"
@@ -6032,7 +6032,7 @@ msgstr "Pacifistas"
 #. placeholder {0}: ts.paper
 #: src/components/_military/battle/SetOrderFormModal.tsx:439
 msgid "Pacifist: orders defending your core regions or revolts cost {orderDiscountPercent}% less <0>{0}</0>"
-msgstr "Pacifistas: įsakymai ginti jūsų pagrindinius regionus ar sukilimus kainuoja {orderDiscountPercent}% mažiau <0>{0}</0>"
+msgstr "Pacifistas: įsakymai ginti tavo pagrindinius regionus ar sukilimus kainuoja {orderDiscountPercent}% mažiau <0>{0}</0>"
 
 #: src/components/_other/shop/ShopHeader.tsx:29
 msgid "Packs"
@@ -6049,7 +6049,7 @@ msgstr "Popierius"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:233
 msgid "Participate in <0>{count}</0> battles"
-msgstr "Dalyvaukite <0>{count}</0> mūšiuose"
+msgstr "Dalyvauk <0>{count}</0> mūšiuose"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:231
 msgid "Participate in Battle"
@@ -6136,7 +6136,7 @@ msgstr "<0/> jau galima balsuoti partijos pirminiuose rinkimuose"
 
 #: src/components/_political/election/CandidateFormModal.tsx:71
 msgid "Paste a link to your campaign article, or leave empty."
-msgstr "Įklijuokite savo rinkimų kampanijos straipsnio nuorodą arba palikite tuščią."
+msgstr "Įklijuok savo rinkimų kampanijos straipsnio nuorodą arba palik tuščią."
 
 #: src/pages/shop/index.tsx:45
 msgid "Payment successful! Thanks for supporting the game <3"
@@ -6219,7 +6219,7 @@ msgstr "Prašome užpildyti CAPTCHA."
 #: src/components/_military/mu/MuFormModal.tsx:65
 #: src/components/_political/party/PartyFormModal.tsx:61
 msgid "Please select a region"
-msgstr "Pasirinkite regioną"
+msgstr "Pasirink regioną"
 
 #: src/components/_layout/map.frontConfig.tsx:26
 msgid "Political"
@@ -6318,7 +6318,7 @@ msgstr "Prezidento rinkimai"
 
 #: src/components/_economy/itemTrading/ItemTradingOrderFormModal.tsx:430
 msgid "Price auto-matches existing orders"
-msgstr ""
+msgstr "Kaina automatiškai atitinka esamus užsakymus"
 
 #: src/components/_political/election/election.frontConfig.tsx:43
 msgid "Primary election"
@@ -6389,7 +6389,7 @@ msgstr "Gamybos bonusas:"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:577
 msgid "Production in<0/> is full, you should start production!"
-msgstr "Gamyba įmonėje <0/> pilna, turėtumėte ją pradėti!"
+msgstr "Gamyba įmonėje <0/> pilna, turėtum ją pradėti!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1972
 msgid "Production is full"
@@ -6511,7 +6511,7 @@ msgstr "Greitai užsidėti geriausius bet kurio lygio daiktus"
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:76
 msgid "Quickly dismantle items"
-msgstr "Greitai išardykite daiktus"
+msgstr "Greitai išardyk daiktus"
 
 #: src/components/_military/battle/BattleHeader.tsx:299
 msgid "Ranking"
@@ -6566,7 +6566,7 @@ msgstr "Pasiek 10 karinį laipsnį"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:435
 msgid "Reach Military Rank 10"
-msgstr "Pasiekite 10 karinį rangą"
+msgstr "Pasiek 10 karinį rangą"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:431
 msgid "Reach military rank 5"
@@ -6579,7 +6579,7 @@ msgstr "Pasiek 5-ąjį karinį laipsnį"
 #. placeholder {0}: leveling.level + 1
 #: src/components/_user/user/Level.tsx:111
 msgid "Reaching level {0} will give you <0>{nextLevelSkillPoints} Skill Points</0>."
-msgstr "Pasiekę {0} lygį gausite <0>{nextLevelSkillPoints} įgūdžių taškų</0>."
+msgstr "Pasiekęs {0} lygį gausi <0>{nextLevelSkillPoints} įgūdžių taškų</0>."
 
 #: src/components/_user/mission/mission.frontConfig.tsx:354
 msgid "Read <0>{count}</0> articles"
@@ -6709,7 +6709,7 @@ msgstr "Regionai"
 
 #: src/components/_political/party/party.frontConfig.tsx:125
 msgid "Regions you occupy generate double the amount of resistance."
-msgstr "Jūsų okupuoti regionai generuoja dvigubai didesnį pasipriešinimą."
+msgstr "Tavo okupuoti regionai generuoja dvigubai didesnį pasipriešinimą."
 
 #: src/components/_military/tournament/TournamentRegisterButton.tsx:131
 msgid "Register"
@@ -7112,11 +7112,11 @@ msgstr "Ieškoti šalių..."
 
 #: src/components/_other/shop/SkinPackModal.tsx:234
 msgid "Search recipient username..."
-msgstr "Ieškokite gavėjo vartotojo vardo..."
+msgstr "Ieškok gavėjo vartotojo vardo..."
 
 #: src/components/_political/government/NominateForm.tsx:53
 msgid "Search username to nominate..."
-msgstr "Ieškokite naudotojo vardo, kurį norite nominuoti..."
+msgstr "Ieškok naudotojo vardo, kurį nori nominuoti..."
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:64
 msgid "See all your workers and companies stats"
@@ -7124,7 +7124,7 @@ msgstr "Peržiūrėk visą savo darbuotojų ir įmonių statistiką"
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:136
 msgid "See your spending and income breakdown"
-msgstr "Peržiūrėkite savo išlaidų ir pajamų suvestinę"
+msgstr "Peržiūrėk savo išlaidų ir pajamų suvestinę"
 
 #: src/components/_military/mu/MuSettings.tsx:77
 msgid "Select a country"
@@ -7136,7 +7136,7 @@ msgstr "Pasirink vietą"
 
 #: src/components/_political/party/PartyFormModal.tsx:110
 msgid "Select a region"
-msgstr "Pasirinkite regioną"
+msgstr "Pasirink regioną"
 
 #: src/components/_economy/inventory/DismantleModal.tsx:247
 msgid "Select all"
@@ -7148,21 +7148,21 @@ msgstr "Pasirink okupuotą regioną"
 
 #: src/components/_user/user/UserDropdown.tsx:255
 msgid "Select banner"
-msgstr "Pasirinkite banerį"
+msgstr "Pasirink banerį"
 
 #: src/components/_political/allianceLaw/AllianceLawTypeSelect.tsx:50
 #: src/components/_political/law/LawTypeSelect.tsx:69
 msgid "Select law type"
-msgstr "Pasirinkite įstatymo tipą"
+msgstr "Pasirink įstatymo tipą"
 
 #: src/components/_political/law/LawFormModal.tsx:215
 #: src/components/_political/law/LawFormModal.tsx:293
 msgid "Select map accent"
-msgstr "Pasirinkite žemėlapio akcentą"
+msgstr "Pasirink žemėlapio akcentą"
 
 #: src/components/_political/partyMotion/PartyMotionTypeSelect.tsx:59
 msgid "Select motion type"
-msgstr "Pasirinkite siūlymo tipą"
+msgstr "Pasirink siūlymo tipą"
 
 #: src/components/_user/user/UserDropdown.tsx:262
 msgid "Select skin"
@@ -7238,7 +7238,7 @@ msgstr "Siųsti žinutę"
 #. placeholder {1}: staticGameConfig.law[ELawType.SEND_MONEY_TO_COUNTRY].externalTaxRate * 100
 #: src/components/_political/law/law.frontConfig.tsx:404
 msgid "Send money to another country. Paper tax on top: {0}% within your alliance, {1}% for external transfers."
-msgstr "Siųsti pinigus kitai šaliai. Papildomas popieriaus mokestis: {0}% jūsų aljanso viduje, {1}% išoriniams pervedimams."
+msgstr "Siųsti pinigus kitai šaliai. Papildomas popieriaus mokestis: {0}% tavo aljanso viduje, {1}% išoriniams pervedimams."
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:51
 msgid "Sergeant"
@@ -7246,7 +7246,7 @@ msgstr "Seržantas"
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:143
 msgid "Set a <0>description</0>"
-msgstr "Nustatykite <0>aprašymą</0>"
+msgstr "Nustatyk <0>aprašymą</0>"
 
 #: src/pages/user/[userId]/referrals.tsx:153
 msgid "Set a referrer"
@@ -7254,11 +7254,11 @@ msgstr "Nustatyti rekomenduotoją"
 
 #: src/components/_political/law/law.frontConfig.tsx:518
 msgid "Set a welcome article for your country"
-msgstr "Nustatykite savo šalies pasveikinimo straipsnį"
+msgstr "Nustatyk savo šalies pasveikinimo straipsnį"
 
 #: src/components/_political/law/law.frontConfig.tsx:523
 msgid "Set a welcome article for your country<0/>"
-msgstr "Nustatykite savo šalies pasveikinimo straipsnį<0/>"
+msgstr "Nustatyk savo šalies pasveikinimo straipsnį<0/>"
 
 #: src/components/_military/battle/BattleOrderActionsDropdown.tsx:129
 msgid "Set bounty"
@@ -7315,11 +7315,11 @@ msgstr "Nustatyti pasveikinimo straipsnį"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:425
 msgid "Set your profile picture"
-msgstr "Nustatykite profilio nuotrauką"
+msgstr "Nustatyk profilio nuotrauką"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:419
 msgid "Set your username"
-msgstr "Nustatykite savo naudotojo vardą"
+msgstr "Nustatyk savo naudotojo vardą"
 
 #: src/components/_user/user/MyAvatar.tsx:54
 #: src/components/_user/user/UserHeader.tsx:226
@@ -7449,7 +7449,7 @@ msgstr "Bendravimas ir žinutės"
 
 #: src/components/_economy/company/CompanyList.tsx:80
 msgid "Some of your companies are disabled."
-msgstr "Kai kurios jūsų įmonės yra išjungtos."
+msgstr "Kai kurios tavo įmonės yra išjungtos."
 
 #: src/components/_layout/LayoutOptions.tsx:159
 msgid "Sound effects"
@@ -7621,7 +7621,7 @@ msgstr "Prenumeratoriai"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:147
 msgid "Successfully logged in!"
-msgstr "Sėkmingai prisijungėte!"
+msgstr "Sėkmingai prisijungei!"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:159
 msgid "Sugar Daddy"
@@ -7633,11 +7633,11 @@ msgstr "Palaikyk žaidimą"
 
 #: src/components/_economy/inventory/DismantleModal.tsx:209
 msgid "Support the game and quickly dismantle items!"
-msgstr "Paremkite žaidimą ir greitai išardykite daiktus!"
+msgstr "Paremk žaidimą ir greitai išardyk daiktus!"
 
 #: src/components/_economy/inventoryAccount/InventoryAccount.tsx:60
 msgid "Support us"
-msgstr "Paremkite mus"
+msgstr "Paremk mus"
 
 #: src/components/_economy/work/WorkChart.tsx:291
 #: src/components/_ui/PremiumButtonTag.tsx:22
@@ -7701,7 +7701,7 @@ msgstr "Prisiekusio priešo sutartys prasideda nuo <0>{0} lojalumo</0> ir gauna 
 #. placeholder {0}: ts.paper
 #: src/components/_military/battle/SetOrderFormModal.tsx:433
 msgid "Sworn enemy: orders against your sworn enemy cost {orderDiscountPercent}% less <0>{0}</0>"
-msgstr "Prisiekęs priešas: įsakymai prieš jūsų prisiekusį priešą kainuoja {orderDiscountPercent}% mažiau <0>{0}</0>"
+msgstr "Prisiekęs priešas: įsakymai prieš tavo prisiekusį priešą kainuoja {orderDiscountPercent}% mažiau <0>{0}</0>"
 
 #: src/components/_political/event/EventList.tsx:72
 msgid "System revolt"
@@ -7799,7 +7799,7 @@ msgstr "Sutartis buvo atšaukta. <0>{0}</0> grąžinta <1/>."
 
 #: src/components/_political/law/LawCostExplanation.tsx:32
 msgid "The cost is the law's base cost scaled by your country's average development."
-msgstr "Kaina yra bazinė įstatymo kaina, apskaičiuojama proporcingai pagal jūsų šalies vidutinį išsivystymą."
+msgstr "Kaina yra bazinė įstatymo kaina, apskaičiuojama proporcingai pagal tavo šalies vidutinį išsivystymą."
 
 #: src/components/_user/user/skills.frontConfig.tsx:59
 msgid "The damage factor increase of critical hits over normal hits"
@@ -7825,7 +7825,7 @@ msgstr "Visas <0/> bonusas taikomas iki <1/> dalies pasaulinio <2>išsivystymo</
 #: src/components/_military/mercenaryContract/MercenaryContractItem.tsx:85
 #: src/components/_military/mercenaryContract/MercenaryContractModal.tsx:64
 msgid "The MU will receive the acceptance fee back, partial payout for damage done, and a 10% penalty fee of <0>{0}</0>. Are you sure?"
-msgstr "MU atgaus priėmimo mokestį, dalinę išmoką už padarytą žalą ir turės sumokėti 10% baudą, lygią <0>{0}</0>. Ar tikrai norite tęsti?"
+msgstr "MU atgaus priėmimo mokestį, dalinę išmoką už padarytą žalą ir turės sumokėti 10% baudą, lygią <0>{0}</0>. Ar tikrai nori tęsti?"
 
 #: src/components/_political/event/event.frontConfig.tsx:88
 msgid "The revolution in <0/> has been suppressed. The government remains in power."
@@ -7853,7 +7853,7 @@ msgstr "Botų, skriptų ar bet kokios formos automatizacijos naudojimas siekiant
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:139
 msgid "This action will submit your MU bid for this contract."
-msgstr "Šis veiksmas pateiks jūsų MU statymą šiai sutarčiai."
+msgstr "Šis veiksmas pateiks tavo MU statymą šiai sutarčiai."
 
 #: src/components/_military/battle/BattleSystem.tsx:799
 msgid "This bounty is reserved for nationals only."
@@ -7881,7 +7881,7 @@ msgstr "Šitas geras, ką?"
 
 #: src/components/_military/battle/LootSummaryCard.tsx:63
 msgid "This is a summary of the loot you received from this battle. It includes any cases you got as well as the most valuable items from the shared loot pool."
-msgstr "Tai suvestinė grobio, kurį gavote šiame mūšyje. Joje pateikiamos gautos dėžės ir vertingiausi daiktai iš bendro grobio fondo."
+msgstr "Tai suvestinė grobio, kurį gavai šiame mūšyje. Joje pateikiamos gautos dėžės ir vertingiausi daiktai iš bendro grobio fondo."
 
 #: src/components/_political/country/CountryHeader.tsx:215
 msgid "This is the value used to calculate most costs: battle orders, alliance, sworn enemy and defensive pact maintenance, laws and upgrade upkeep."
@@ -8278,7 +8278,7 @@ msgstr "Atrakinti mygtuką \"Padėti visiems\""
 
 #: src/components/_user/premium/PremiumFeatureList.tsx:106
 msgid "Unlock Produce all button"
-msgstr "Atrakinkite mygtuką \"Gaminti viską\""
+msgstr "Atrakink mygtuką \"Gaminti viską\""
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1958
 msgid "Unlocked pack"
@@ -8640,7 +8640,7 @@ msgstr "Laukiama {0} lygio"
 
 #: src/components/_user/worker/WorkerEditFormModal.tsx:168
 msgid "Waiting for the worker to accept or reject the wage reduction. You cannot change the wage until they respond."
-msgstr "Laukiama, kol darbuotojas priims arba atmes atlyginimo sumažinimą. Negalite keisti atlyginimo, kol jis neatsakys."
+msgstr "Laukiama, kol darbuotojas priims arba atmes atlyginimo sumažinimą. Negali keisti atlyginimo, kol jis neatsakys."
 
 #: src/components/_economy/itemTrading/ItemTradingOrderItem.tsx:155
 msgid "wants"
@@ -8746,7 +8746,7 @@ msgstr "Visa gamyba"
 #: src/components/_political/allianceLaw/AllianceLawFormModal.tsx:136
 #: src/components/_political/law/LawFormModal.tsx:181
 msgid "Why do you want to propose this law?"
-msgstr "Kodėl norite pateikti šį įstatymo projektą?"
+msgstr "Kodėl nori pateikti šį įstatymo projektą?"
 
 #: src/components/_other/shop/skinPack.frontConfig.tsx:36
 msgid "Winter Soldier Pack"
@@ -8856,7 +8856,7 @@ msgstr "XP"
 #. placeholder {0}: companiesLimit ?? 1
 #: src/components/_economy/company/CompanyDropdown.tsx:275
 msgid "You already have {0} active companies. Disable one first."
-msgstr "Aktyvių įmonių jau turite: {0}. Pirmiausia išjunkite vieną."
+msgstr "Aktyvių įmonių jau turi: {0}. Pirmiausia išjunk vieną."
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:25
 msgid "You are a beautiful person"
@@ -8881,15 +8881,15 @@ msgstr "Jau esi kitos šalies viceprezidentas. Pirmiausia atsistatydink."
 #: src/pages/companies.tsx:45
 #: src/pages/user/[userId]/companies.tsx:64
 msgid "You are jobless"
-msgstr "Neturite darbo"
+msgstr "Neturi darbo"
 
 #: src/components/_political/partyMotion/PartyMotionList.tsx:44
 msgid "You are not a council member of this party"
-msgstr "Jūs nesate šios partijos tarybos narys"
+msgstr "Nesi šios partijos tarybos narys"
 
 #: src/pages/events/index.tsx:132
 msgid "You are not participating"
-msgstr "Jūs nedalyvaujate"
+msgstr "Nedalyvauji"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:53
 msgid "You are very skilled!"
@@ -8922,11 +8922,11 @@ msgstr "Į pasaulį atvedėte 10 kūdikių (>= {0} lygis)"
 
 #: src/components/_economy/inventory/DismantleModal.tsx:211
 msgid "You can dismantle items from your inventory by selecting an item."
-msgstr "Išardyti daiktus iš savo inventoriaus galite pasirinkę daiktą."
+msgstr "Išardyti daiktus iš savo inventoriaus gali pasirinkęs daiktą."
 
 #: src/components/_political/election/CandidateFormModal.tsx:61
 msgid "You can optionally link a campaign article to your candidacy."
-msgstr "Prie savo kandidatūros galite susieti rinkimų kampanijos straipsnį."
+msgstr "Prie savo kandidatūros gali susieti rinkimų kampanijos straipsnį."
 
 #: src/components/_user/user/Level.tsx:85
 msgid "You can upgrade your skills!"
@@ -8934,11 +8934,11 @@ msgstr "Gali patobulinti savo įgūdžius!"
 
 #: src/pages/country/[countryId]/citizenship.tsx:61
 msgid "You cannot apply for citizenship if you have a government/congress role"
-msgstr "Negalite prašyti pilietybės, jei einate pareigas vyriausybėje arba kongrese"
+msgstr "Negali prašyti pilietybės, jei eini pareigas vyriausybėje arba kongrese"
 
 #: src/pages/party/[partyId]/applications.tsx:28
 msgid "You don't have permission to view applications."
-msgstr "Neturite teisės peržiūrėti paraiškų."
+msgstr "Neturi teisės peržiūrėti paraiškų."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1524
 msgid "You earned gems from a banner sale!"
@@ -8962,7 +8962,7 @@ msgstr "Padovanojai kam nors rėmėjo plano prenumeratą <3"
 
 #: src/pages/country/[countryId]/citizenship.tsx:48
 msgid "You gonna be automatically approved because the country population is below"
-msgstr "Jūsų prašymas bus automatiškai patvirtintas, nes šalies gyventojų skaičius yra mažesnis nei"
+msgstr "Tavo prašymas bus automatiškai patvirtintas, nes šalies gyventojų skaičius yra mažesnis nei"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:93
 msgid "You have a case!"
@@ -8970,28 +8970,28 @@ msgstr "Gavai bylą!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1136
 msgid "You have been demoted from commander in <0/> by <1/>"
-msgstr "Netekote <0/> vado pareigų - jus pažemino <1/>"
+msgstr "Netekai <0/> vado pareigų - tave pažemino <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:323
 msgid "You have been elected as the new leader of <0/>"
-msgstr "Buvote išrinktas naujuoju <0/> lyderiu"
+msgstr "Buvai išrinktas naujuoju <0/> lyderiu"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1122
 msgid "You have been promoted to commander in <0/> by <1/>"
-msgstr "Tapote <0/> vadu, jus paaukštino <1/>"
+msgstr "Tapai <0/> vadu, tave paaukštino <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1108
 msgid "You have been removed from <0/> by <1/>"
-msgstr "Iš <0/> jus pašalino <1/>"
+msgstr "Iš <0/> tave pašalino <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:442
 msgid "You have been transferred from <0/> to <1/>"
-msgstr "Jūs buvote perkeltas iš <0/> į <1/>"
+msgstr "Buvai perkeltas iš <0/> į <1/>"
 
 #. placeholder {0}: 1
 #: src/components/_user/notification/notification.frontConfig.tsx:683
 msgid "You have consumed <0>{0}</0>, it's effect starts now and ends in <1>{buffDuration}h</1>."
-msgstr "Suvartojote <0>{0}</0>, jo poveikis prasideda dabar ir baigsis po <1>{buffDuration}h</1>."
+msgstr "Suvartojai <0>{0}</0>, jo poveikis prasideda dabar ir baigsis po <1>{buffDuration}h</1>."
 
 #: src/pages/country/[countryId]/government.tsx:46
 msgid "You have resigned from the congress"
@@ -8999,17 +8999,17 @@ msgstr "Pasitraukei iš kongreso"
 
 #: src/pages/country/[countryId]/government.tsx:38
 msgid "You have resigned from the government"
-msgstr "Jūs atsistatydinote iš vyriausybės"
+msgstr "Atsistatydinai iš vyriausybės"
 
 #. placeholder {0}: gameConfig?.user.canTakeControlAtLevel
 #: src/pages/country/[countryId]/index.tsx:103
 msgid "You have to be level {0} to take control of a country."
-msgstr "Norėdami perimti šalies valdymą, turite būti bent {0} lygio."
+msgstr "Norėdamas perimti šalies valdymą, turi būti bent {0} lygio."
 
 #. placeholder {0}: gameConfig?.user.takeControlCooldownInDays
 #: src/pages/country/[countryId]/index.tsx:105
 msgid "You have to wait {0} days before taking control of a country again."
-msgstr "Turite palaukti {0} dienas, kol vėl galėsite perimti šalies kontrolę."
+msgstr "Turi palaukti {0} dienas, kol vėl galėsi perimti šalies kontrolę."
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:124
 msgid "You helped the dev find a bug, ty <3"
@@ -9040,7 +9040,7 @@ msgstr "Išėjote iš darbo!"
 #. placeholder {0}: gameConfig.election.candidateMinLevel
 #: src/components/_political/election/Election.tsx:133
 msgid "You must be at least level {0} to become a candidate."
-msgstr "Turite būti bent {0} lygio, kad taptumėte kandidatu."
+msgstr "Turi būti bent {0} lygio, kad taptum kandidatu."
 
 #. placeholder {0}: gameConfig.region.resistanceContributionMinLevel
 #. placeholder {0}: gameConfig.unrest.contributionMinLevel
@@ -9052,15 +9052,15 @@ msgstr "Kad galėtum prisidėti, turi būti bent {0} lygio."
 #. placeholder {0}: gameConfig.election.voteMinLevel
 #: src/components/_political/election/Election.tsx:226
 msgid "You must be at least level {0} to vote."
-msgstr "Turite būti bent {0} lygio, kad galėtumėte balsuoti."
+msgstr "Turi būti bent {0} lygio, kad galėtum balsuoti."
 
 #: src/components/_user/premium/PremiumActions.tsx:42
 msgid "You must be on web to subscribe"
-msgstr "Norėdami užsiprenumeruoti, turite būti prisijungę per svetainę"
+msgstr "Norėdamas užsiprenumeruoti, turi būti prisijungęs per svetainę"
 
 #: src/components/_political/government/PoliticalEthicsSelect.tsx:115
 msgid "You must spend all 3 ethics points ({pointsRemaining} remaining)"
-msgstr "Privalote išleisti visus 3 etikos taškus (liko {pointsRemaining})"
+msgstr "Privalai išleisti visus 3 etikos taškus (liko {pointsRemaining})"
 
 #: src/components/_user/UserEquipments.tsx:156
 msgid "You need to equip a weapon first"
@@ -9091,20 +9091,20 @@ msgstr "Gavai \"{skinTitle}\" skiną!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:595
 msgid "You sold items."
-msgstr "Pardavėte daiktus."
+msgstr "Pardavei daiktus."
 
 #. placeholder {0}: data.bannerTitle
 #: src/components/_user/notification/notification.frontConfig.tsx:1447
 msgid "You successfully gifted \"{0}\" to <0/>!"
-msgstr "Sėkmingai padovanojote \"{0}\" žaidėjui <0/>!"
+msgstr "Sėkmingai padovanojai \"{0}\" žaidėjui <0/>!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1713
 msgid "You successfully gifted \"{skinTitle}\" to <0/>!"
-msgstr "Sėkmingai padovanojote \"{skinTitle}\" žaidėjui <0/>!"
+msgstr "Sėkmingai padovanojai \"{skinTitle}\" žaidėjui <0/>!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1017
 msgid "You successfully gifted a premium subscription to <0/>!"
-msgstr "Sėkmingai padovanojote premium prenumeratą <0/>!"
+msgstr "Sėkmingai padovanojai premium prenumeratą <0/>!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1781
 msgid "You successfully gifted the skin pack \"{skinPackTitle}\" to <0/>!"
@@ -9137,11 +9137,11 @@ msgstr "Tave išrinko"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:59
 msgid "You were elected as a congress member of your country"
-msgstr "Buvote išrinktas savo šalies Kongreso nariu"
+msgstr "Buvai išrinktas savo šalies Kongreso nariu"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:52
 msgid "You were elected as president of your country"
-msgstr "Buvote išrinktas savo šalies prezidentu"
+msgstr "Buvai išrinktas savo šalies prezidentu"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:46
 msgid "You were here at the beginning of War Era"
@@ -9149,11 +9149,11 @@ msgstr "Čia buvai nuo pat War Era pradžios"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:236
 msgid "You were nominated as a government member of a country"
-msgstr "Buvote paskirtas šalies vyriausybės nariu"
+msgstr "Buvai paskirtas šalies vyriausybės nariu"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:67
 msgid "You were nominated as vice president of your country"
-msgstr "Buvote paskirtas savo šalies viceprezidentu"
+msgstr "Buvai paskirtas savo šalies viceprezidentu"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:21
 msgid "You were so close"
@@ -9222,7 +9222,7 @@ msgstr "Tavo <0>gamybos</0> juosta pilna! Spustelėk, kad pagamintum daiktus ir 
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:96
 msgid "Your account has been automatically reported for cheating"
-msgstr "Jūsų paskyra buvo automatiškai pranešta dėl sukčiavimo"
+msgstr "Tavo paskyra buvo automatiškai pranešta dėl sukčiavimo"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:74
 msgid "Your ancestors are proud"
@@ -9230,16 +9230,16 @@ msgstr "Tavo protėviai didžiuojasi"
 
 #: src/components/_political/government/AnnouncementForm.tsx:23
 msgid "Your announcement to the country..."
-msgstr "Jūsų skelbimas šaliai..."
+msgstr "Tavo skelbimas šaliai..."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:367
 #: src/components/_user/notification/notification.frontConfig.tsx:1067
 msgid "Your application to <0/> has been rejected"
-msgstr "Jūsų paraiška į <0/> buvo atmesta"
+msgstr "Tavo paraiška į <0/> buvo atmesta"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:201
 msgid "Your article reached 2% of the active population in score (min 10)"
-msgstr "Jūsų straipsnis surinko balų, lygių 2 % aktyvios populiacijos skaičiui (min. 10)"
+msgstr "Tavo straipsnis surinko balų, lygių 2 % aktyvios populiacijos skaičiui (min. 10)"
 
 #. placeholder {0}: data.bannerTitle
 #: src/components/_user/notification/notification.frontConfig.tsx:1538
@@ -9248,7 +9248,7 @@ msgstr "Tavo reklamjuostė \"{0}\" buvo patvirtinta ir dabar ją galima rasti pa
 
 #: src/components/_user/notification/notification.frontConfig.tsx:698
 msgid "Your buff(s) will expire in less than 1 hour. The debuff phase will begin soon."
-msgstr "Jūsų pastiprinimai baigs galioti greičiau nei po 1 valandos. Netrukus prasidės susilpninimo etapas."
+msgstr "Tavo pastiprinimai baigs galioti greičiau nei po 1 valandos. Netrukus prasidės susilpninimo etapas."
 
 #: src/pages/country/[countryId]/index.tsx:142
 msgid "Your citizenship is going to change"
@@ -9260,15 +9260,15 @@ msgstr "Tavo šalis"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2032
 msgid "Your country is under attack!"
-msgstr "Jūsų šalis puolama!"
+msgstr "Tavo šalis puolama!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2035
 msgid "Your country launched an attack!"
-msgstr "Jūsų šalis pradėjo puolimą!"
+msgstr "Tavo šalis pradėjo puolimą!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:937
 msgid "Your country started a revolt in <0/> against <1/>"
-msgstr "Jūsų šalis pradėjo sukilimą vietovėje <0/> prieš <1/>"
+msgstr "Tavo šalis pradėjo sukilimą vietovėje <0/> prieš <1/>"
 
 #: src/components/_economy/workOffer/WorkOfferList.tsx:109
 msgid "Your current job"
@@ -9276,7 +9276,7 @@ msgstr "Tavo dabartinis darbas"
 
 #: src/components/_economy/itemTrading/ItemTradingOrderItem.tsx:146
 msgid "Your current order"
-msgstr "Jūsų dabartinis užsakymas"
+msgstr "Tavo dabartinis užsakymas"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1687
 msgid "Your daily missions have been reset! Complete them to earn rewards."
@@ -9284,27 +9284,27 @@ msgstr "Tavo dienos misijos buvo atnaujintos! Įvykdyk jas ir gauk apdovanojimų
 
 #: src/pages/user/[userId]/settings.tsx:49
 msgid "Your email"
-msgstr "Jūsų el. paštas"
+msgstr "Tavo el. paštas"
 
 #. placeholder {0}: worker.previousWage
 #. placeholder {1}: worker.wage
 #: src/components/_user/worker/WageReductionAlert.tsx:68
 msgid "Your employer wants to reduce your wage from <0>{0}</0> to <1>{1}</1>."
-msgstr "Darbdavys nori sumažinti jūsų atlyginimą nuo <0>{0}</0> iki <1>{1}</1>."
+msgstr "Darbdavys nori sumažinti tavo atlyginimą nuo <0>{0}</0> iki <1>{1}</1>."
 
 #. placeholder {0}: data.oldWage
 #. placeholder {1}: data.newWage
 #: src/components/_user/notification/notification.frontConfig.tsx:472
 msgid "Your employer wants to reduce your wage in <0/> from <1>{0}</1> to <2>{1}</2>. Accept or reject this change."
-msgstr "Jūsų darbdavys nori sumažinti jūsų atlyginimą įmonėje <0/> nuo <1>{0}</1> iki <2>{1}</2>. Priimkite arba atmeskite šį pakeitimą."
+msgstr "Tavo darbdavys nori sumažinti tavo atlyginimą įmonėje <0/> nuo <1>{0}</1> iki <2>{1}</2>. Priimk arba atmesk šį pakeitimą."
 
 #: src/components/_military/battle/EndedBattlesList.tsx:84
 msgid "Your enemies"
-msgstr "Jūsų priešai"
+msgstr "Tavo priešai"
 
 #: src/components/_user/auth/WelcomeModal.tsx:80
 msgid "Your infos have been saved."
-msgstr "Jūsų duomenys išsaugoti."
+msgstr "Tavo duomenys išsaugoti."
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:85
 msgid "Your inventory holds all your items. Let's see what you've got!"
@@ -9325,7 +9325,7 @@ msgstr "Sėkmė atostogauja"
 
 #: src/components/_military/mu/MuFormModal.tsx:108
 msgid "Your military unit name"
-msgstr "Jūsų karinio dalinio pavadinimas"
+msgstr "Tavo karinio dalinio pavadinimas"
 
 #: src/components/_military/mu/MuSettings.tsx:53
 msgid "Your military unit nationality is the country it represents. Changing it is free and can only be done once every {cooldownDays} days."
@@ -9333,11 +9333,11 @@ msgstr "Tavo karinio vieneto pilietybė yra šalis, kuriai jis atstovauja. Jos p
 
 #: src/components/_military/mercenaryContract/BuyMercenaryReputationButton.tsx:50
 msgid "Your MU has <0/> reputation and cannot bid on mercenary contracts. Pay to buy back reputation (once per day)."
-msgstr "Jūsų MU turi <0/> reputacijos ir negali dalyvauti samdinių sutarčių aukcionuose. Sumokėkite, kad išsipirktumėte reputaciją (kartą per dieną)."
+msgstr "Tavo MU turi <0/> reputacijos ir negali dalyvauti samdinių sutarčių aukcionuose. Sumokėk, kad išsipirktum reputaciją (kartą per dieną)."
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:230
 msgid "Your MU must have enough money to cover the acceptance fee to bid. Payment is only deducted if you win, and refunded on contract completion."
-msgstr "Jūsų MU turi turėti pakankamai pinigų priėmimo mokesčiui padengti, kad galėtų atlikti statymą. Mokestis atskaitomas tik laimėjus ir grąžinamas įvykdžius sutartį."
+msgstr "Tavo MU turi turėti pakankamai pinigų priėmimo mokesčiui padengti, kad galėtų atlikti statymą. Mokestis atskaitomas tik laimėjus ir grąžinamas įvykdžius sutartį."
 
 #: src/components/_economy/market/MarketHeader.tsx:13
 msgid "Your offers"
@@ -9345,15 +9345,15 @@ msgstr "Tavo pasiūlymai"
 
 #: src/components/_political/party/PartyFormModal.tsx:98
 msgid "Your party name"
-msgstr "Jūsų partijos pavadinimas"
+msgstr "Tavo partijos pavadinimas"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:999
 msgid "Your premium subscription has been activated!"
-msgstr "Jūsų premium prenumerata aktyvuota!"
+msgstr "Tavo premium prenumerata aktyvuota!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1008
 msgid "Your premium subscription has expired!"
-msgstr "Jūsų \"Premium\" prenumerata baigėsi!"
+msgstr "Tavo \"Premium\" prenumerata baigėsi!"
 
 #: src/components/_military/damageRanking/DamageRankingList.tsx:195
 msgid "Your rank"
@@ -9369,7 +9369,7 @@ msgstr "Tavo komanda"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1371
 msgid "Your team <0/> has been eliminated from the <1/>"
-msgstr "Jūsų komanda <0/> buvo pašalinta iš <1/>"
+msgstr "Tavo komanda <0/> buvo pašalinta iš <1/>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1282
 msgid "Your team <0/> won a round in <1/>!"
@@ -9387,7 +9387,7 @@ msgstr "<0/> tavo atlyginimas pasikeitė nuo <1>{0}</1> į <2>{1}</2>"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1699
 msgid "Your weekly missions have been reset! Complete them to earn rewards."
-msgstr "Jūsų savaitinės misijos buvo atnaujintos! Įvykdykite jas ir gaukite apdovanojimų."
+msgstr "Tavo savaitinės misijos buvo atnaujintos! Įvykdyk jas ir gauk apdovanojimų."
 
 #: src/components/_user/auth/ConnectFromModal.tsx:227
 msgid "your@email.com"

--- a/lt/messages.po
+++ b/lt/messages.po
@@ -742,7 +742,7 @@ msgstr "<0>{ethicDepositBonus}</0> iš <1/> agrarinės etikos telkinių bonuso."
 
 #: src/components/_economy/company/CompanyProductionBonusTag.tsx:64
 msgid "<0>{ethicSpecializationBonus}</0> from <1/> industrialist ethics specialization bonus."
-msgstr "<0>{ethicSpecializationBonus}</0> iš pramonininko etikos specializacijos bonuso."
+msgstr "<0>{ethicSpecializationBonus}</0> iš <1/> pramonininko etikos specializacijos bonuso."
 
 #: src/components/_economy/company/CompanyProductionBonusTag.tsx:53
 msgid "<0>{strategicBonus}</0> from <1/> strategic resources production bonus."
@@ -792,7 +792,7 @@ msgstr "<0>Kas <1/> bendros abiejų pusių padarytos žalos į mūšio fondą pr
 #. placeholder {2}: 10
 #: src/components/_user/worker/WorkerItem.tsx:122
 msgid "<0>Everyday passed working for same employer, the fidelity bonus increases by <1>{0}</1>.</0><2>It increase by <3>{1}</3> the production bonus until <4>{2}</4>.</2><5>This bonus is applied after work. So it is not counted in wage.</5>"
-msgstr "<0>Kiekvieną dieną dirbant tam pačiam darbdaviui, lojalumo bonusas padidėja <1>{0}</1>.</0><2>Ji padidina gamybos bonusą <3>{1}</3> iki <4>{2}</4>.</2><5>Šis bonusas pritaikoma po darbo, todėl į atlyginimą neįskaičiuojama.</5>"
+msgstr "<0>Kiekvieną dieną dirbant tam pačiam darbdaviui, lojalumo bonusas padidėja <1>{0}</1>.</0><2>Ji padidina gamybos bonusą <3>{1}</3> iki <4>{2}</4>.</2><5>Šis bonusas pritaikomas po darbo, todėl į atlyginimą neįskaičiuojama.</5>"
 
 #: src/components/_economy/company/CompanyProduce.tsx:81
 msgid "<0>Filled with <1>Production Points</1> by employees working and from the automated engine.</0><2>Only the company owner can spend it to produce items.</2>"

--- a/lt/messages.po
+++ b/lt/messages.po
@@ -493,7 +493,7 @@ msgstr "<0/> pasiekė {0} lygį!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:560
 msgid "<0/> referred you to the game."
-msgstr "<0/> pakvietė jus į žaidimą."
+msgstr "<0/> pakvietė tave į žaidimą."
 
 #. placeholder {0}: data.messageId && <MessageItemById messageId={data.messageId} />
 #: src/components/_user/notification/notification.frontConfig.tsx:866
@@ -4064,7 +4064,7 @@ msgstr "Dalinimo laimėtojas"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2119
 msgid "Giveaway Won!"
-msgstr "Laimėjote dalybas!"
+msgstr "Laimėjai dalybas!"
 
 #. placeholder {0}: levelConfig.stats.attackBonus
 #: src/components/_other/upgrade/upgrade.frontConfig.tsx:97
@@ -5628,7 +5628,7 @@ msgstr "Aljanso įstatymų dar nėra"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:231
 msgid "No API tokens yet. Create one to get started."
-msgstr "API prieigos raktų dar nėra. Sukurki vieną, kad galėtum pradėti."
+msgstr "API prieigos raktų dar nėra. Sukurk vieną, kad galėtum pradėti."
 
 #: src/components/_user/auth/ConnectFromModal.tsx:140
 msgid "No authorization code provided."
@@ -7399,7 +7399,7 @@ msgstr "Įgūdžiai išsaugoti!"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1952
 msgid "Skin gift received"
-msgstr "Gavote skiną dovanų"
+msgstr "Gavai skiną dovanų"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1950
 msgid "Skin gift sent"
@@ -7773,7 +7773,7 @@ msgstr "Čia tai epika!"
 
 #: src/components/_user/user/skills.frontConfig.tsx:98
 msgid "The <0>Production Points</0> you generate each time you work"
-msgstr "Kiek <0>gamybos taškų</0> gaunate kiekvieną kartą dirbdami"
+msgstr "Kiek <0>gamybos taškų</0> gauni kiekvieną kartą dirbdamas"
 
 #: src/components/_user/user/skills.frontConfig.tsx:40
 msgid "The base value for <0>Damages</0> calculation."
@@ -8138,7 +8138,7 @@ msgstr "Turnyras sukurtas"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2059
 msgid "Tournament Eliminated"
-msgstr "Iškritote iš turnyro"
+msgstr "Pašalinta iš turnyro"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2057
 msgid "Tournament Ended"
@@ -8158,7 +8158,7 @@ msgstr "Turnyras prasidėjo"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2050
 msgid "Tournament Won!"
-msgstr "Laimėjote turnyrą!"
+msgstr "Laimėtas turnyras!"
 
 #: src/components/_economy/transaction/TransactionList.tsx:71
 #: src/pages/market/index.tsx:63
@@ -8830,7 +8830,7 @@ msgstr "Blogiausias"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:82
 msgid "Wow congratulations! Anyway have you considered buying premium?"
-msgstr "Oho, sveikinimai! Beje, gal svarstėte įsigyti \"Premium\"?"
+msgstr "Oho, sveikinimai! Beje, gal svarstei įsigyti \"Premium\"?"
 
 #: src/components/_political/law/LawFormModal.tsx:170
 #: src/components/_political/law/LawList.tsx:52
@@ -8909,7 +8909,7 @@ msgstr "Nupirkai kūrėjui kavos <3"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:593
 msgid "You bought items."
-msgstr "Nusipirkote daiktų."
+msgstr "Nusipirkai daiktų."
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:77
 msgid "You broke the rng"
@@ -8918,7 +8918,7 @@ msgstr "Sugadinai RNG"
 #. placeholder {0}: staticGameConfig.referral.levelNeededForBadge
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:172
 msgid "You brought 10 babies to the world (>= lvl {0})"
-msgstr "Į pasaulį atvedėte 10 kūdikių (>= {0} lygis)"
+msgstr "Į pasaulį atvedėi 10 kūdikių (>= {0} lygis)"
 
 #: src/components/_economy/inventory/DismantleModal.tsx:211
 msgid "You can dismantle items from your inventory by selecting an item."
@@ -9021,7 +9021,7 @@ msgstr "Padėjai kūrėjui rasti klaidą, ačiū <3"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:211
 msgid "You helped translate the game into another language"
-msgstr "Padėjote išversti žaidimą į kitą kalbą"
+msgstr "Padėjai išversti žaidimą į kitą kalbą"
 
 #. placeholder {0}: staticGameConfig.referral.levelNeededForBadge
 #. placeholder {1}: staticGameConfig.referral.lifeTimeBadgeMoneySharePercent
@@ -9031,11 +9031,11 @@ msgstr "Pakvietei draugą arba spaminei forume. Kai jie pasieks {0} lygį, gausi
 
 #: src/components/_user/worker/WageReductionAlert.tsx:44
 msgid "You left the company."
-msgstr "Išėjote iš įmonės."
+msgstr "Išėjai iš įmonės."
 
 #: src/components/_economy/company/CompanyDropdown.tsx:65
 msgid "You left your job!"
-msgstr "Išėjote iš darbo!"
+msgstr "Išėjai iš darbo!"
 
 #. placeholder {0}: gameConfig.election.candidateMinLevel
 #: src/components/_political/election/Election.tsx:133
@@ -9083,7 +9083,7 @@ msgstr "Gavai grobio daiktą už <0>#{0}</0> vietą <1/>"
 #. placeholder {1}: data.rank && ( <> position{' '} <Typo fw='bold' color='text1'> #{data.rank} </Typo> </> )
 #: src/components/_user/notification/notification.frontConfig.tsx:1392
 msgid "You received a reward for {0} {1} in<0/> tier in the ranking <1/>"
-msgstr "Gavote atlygį už {0} {1} <0/>reitingo <1/> pakopoje"
+msgstr "Gavai atlygį už {0} {1} <0/>reitingo <1/> pakopoje"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1896
 msgid "You received the skin \"{skinTitle}\"!"
@@ -9178,7 +9178,7 @@ msgstr "Laimėjai MU turnyrą"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:86
 msgid "You worked 100 times"
-msgstr "Dirbote 100 kartų"
+msgstr "Dirbai 100 kartų"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:220
 msgid "You're all set!"
@@ -9391,7 +9391,7 @@ msgstr "Tavo savaitinės misijos buvo atnaujintos! Įvykdyk jas ir gauk apdovano
 
 #: src/components/_user/auth/ConnectFromModal.tsx:227
 msgid "your@email.com"
-msgstr "jusu@email.com"
+msgstr "tavo@email.com"
 
 #: src/components/_political/chat/ChatConversationsMenu.tsx:152
 #: src/components/_social/ArticleList.tsx:195

--- a/lt/messages.po
+++ b/lt/messages.po
@@ -792,7 +792,7 @@ msgstr "<0>Kas <1/> bendros abiejų pusių padarytos žalos į mūšio fondą pr
 #. placeholder {2}: 10
 #: src/components/_user/worker/WorkerItem.tsx:122
 msgid "<0>Everyday passed working for same employer, the fidelity bonus increases by <1>{0}</1>.</0><2>It increase by <3>{1}</3> the production bonus until <4>{2}</4>.</2><5>This bonus is applied after work. So it is not counted in wage.</5>"
-msgstr "<0>Kiekvieną dieną dirbant tam pačiam darbdaviui, lojalumo bonusas padidėja <1>{0}</1>.</0><2>Jis padidina gamybos bonusą <3>{1}</3> iki <4>{2}</4>.</2><5>Šis bonusas pritaikomas po darbo, todėl į atlyginimą neįskaičiuojama.</5>"
+msgstr "<0>Kiekvieną dieną dirbant tam pačiam darbdaviui, lojalumo bonusas padidėja <1>{0}</1>.</0><2>Jis padidina gamybos bonusą <3>{1}</3> iki <4>{2}</4>.</2><5>Šis bonusas pritaikomas po darbo, todėl į atlyginimą neįskaičiuojamas.</5>"
 
 #: src/components/_economy/company/CompanyProduce.tsx:81
 msgid "<0>Filled with <1>Production Points</1> by employees working and from the automated engine.</0><2>Only the company owner can spend it to produce items.</2>"
@@ -8918,7 +8918,7 @@ msgstr "Sugadinai RNG"
 #. placeholder {0}: staticGameConfig.referral.levelNeededForBadge
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:172
 msgid "You brought 10 babies to the world (>= lvl {0})"
-msgstr "Į pasaulį atvedėi 10 kūdikių (>= {0} lygis)"
+msgstr "Į pasaulį atvedei 10 kūdikių (>= {0} lygis)"
 
 #: src/components/_economy/inventory/DismantleModal.tsx:211
 msgid "You can dismantle items from your inventory by selecting an item."

--- a/lt/messages.po
+++ b/lt/messages.po
@@ -9077,7 +9077,7 @@ msgstr "Baigėsi tavo \"Premium\" dovanos iš <0/> galiojimas! Ar apsvarstytum p
 #. placeholder {0}: data.rank
 #: src/components/_user/notification/notification.frontConfig.tsx:1266
 msgid "You received a loot item for rank <0>#{0}</0> in <1/>"
-msgstr "Gavai grobio daiktą už <0>#{0}</0> vietą <1/>"
+msgstr "Gavai grobį už <0>#{0}</0> vietą <1/>"
 
 #. placeholder {0}: data.muId ? ( <MuName muId={data.muId} /> ) : data.countryId ? ( <CountryName countryId={data.countryId} /> ) : ( 'your' )
 #. placeholder {1}: data.rank && ( <> position{' '} <Typo fw='bold' color='text1'> #{data.rank} </Typo> </> )


### PR DESCRIPTION
#### Fix minor typos, grammar, and missing tags in Lithuanian translation

## Changes
* **Formatting Tags:** Restored missing `<1/>` tags in production/ethics bonus strings to prevent UI rendering issues.
* **Grammar & Typos:** Fixed a typo in the referral badge description and corrected a gender agreement issue regarding the fidelity bonus.
* **Tone Consistency:** Finalized the shift to a consistent, informal tone ("Tu/Tavo") across all strings.

[aKusaNas](https://app.warera.io/user/690b1d5d5c3b907278d92d44)