### PR TITLE
Arabic translation Maintenance

### DIFF
--- a/ar/messages.po
+++ b/ar/messages.po
@@ -3328,7 +3328,7 @@ msgstr "تم حلّه <0/>"
 #: src/components/_user/mission/mission.frontConfig.tsx:187
 #: src/pages/user/[userId]/inventory.tsx:52
 msgid "Dismantle"
-msgstr "تفكيك"
+msgstr "تفكيك متعدد"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:189
 msgid "Dismantle <0>{count}</0> items"


### PR DESCRIPTION
I've noticed that many new players who don't speak English can't figure out how to dismantle items because the button says "Supporters Only." so they thought you cannot dismantle items without paying lol

By updating the translation and changing the button text from "Dismantle" to "Quick Dismantle" ( in arabic ) it would make it clear that only the quick dismantle feature is for supporters, not dismantling items in general. This should help reduce the confusion.