### PR TITLE
Update Serbian translation for v0.25.3-beta

### DIFF
--- a/sr/messages.po
+++ b/sr/messages.po
@@ -157,11 +157,11 @@ msgstr "{completedCount}/{totalCount} завршено"
 
 #: src/components/_user/user/SkillUpgrade.tsx:267
 msgid "{draftPrestigeCount} prestige point(s) on this skill ({savedPrestigeCount} saved, locked until reset)"
-msgstr ""
+msgstr "{draftPrestigeCount} поен(а) престижа на овој вештини ({savedPrestigeCount} сачувано, закључано до ресетовања)"
 
 #: src/components/_user/user/Level.tsx:143
 msgid "{prestigeLevel} Prestige Points"
-msgstr ""
+msgstr "{prestigeLevel} поена престижа"
 
 #: src/components/_military/tournament/TournamentRegisteredTag.tsx:43
 msgid "{registeredCount} {entityLabel} registered"
@@ -173,7 +173,7 @@ msgstr "{roundsToWin} рунди до победе "
 
 #: src/components/_user/user/SkillUpgrade.tsx:373
 msgid "{savedPrestigeCount} prestige point(s) active on this skill"
-msgstr ""
+msgstr "{savedPrestigeCount} активних поена престижа на овој вештини"
 
 #. placeholder {0}: staticGameConfig.battle.roundsToWin
 #: src/components/_military/battle/RoundScore.tsx:50
@@ -198,11 +198,11 @@ msgstr "/дан"
 
 #: src/components/_military/battle/MyBattlesRecapCard.tsx:178
 msgid "+{hiddenBattles} more battles"
-msgstr ""
+msgstr "+још {hiddenBattles} битака"
 
 #: src/components/_user/user/Level.tsx:152
 msgid "+{xpBonusPercent}% XP"
-msgstr ""
+msgstr "+{xpBonusPercent}% XP-а"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:381
 #: src/components/_user/notification/notification.frontConfig.tsx:1095
@@ -749,7 +749,7 @@ msgstr "<0>{0}</0>/дан"
 #. placeholder {0}: companiesLimit ?? 99
 #: src/components/_economy/company/CompanyList.tsx:118
 msgid "<0>{activeCompaniesCount}/{0}</0> Companies"
-msgstr ""
+msgstr "<0>{activeCompaniesCount}/{0}</0> компанија"
 
 #: src/components/_economy/company/CompanyProductionBonusTag.tsx:78
 msgid "<0>{depositBonus}</0> from deposit resources in <1/>."
@@ -1341,7 +1341,7 @@ msgstr "Прихваћено"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:303
 msgid "Access granted"
-msgstr ""
+msgstr "Приступ одобрен"
 
 #: src/components/_military/battle/BattleHeader.tsx:118
 msgid "Access war"
@@ -1366,7 +1366,7 @@ msgstr "Акције"
 
 #: src/components/_user/user/Level.tsx:160
 msgid "activated"
-msgstr ""
+msgstr "активирано"
 
 #: src/components/_military/battle/BattlesHeader.tsx:27
 #: src/components/_military/mercenaryContract/MercenaryAuctionList.tsx:134
@@ -1631,7 +1631,7 @@ msgstr "Анимирани <0>GIF</0> као аватар"
 
 #: src/pages/country/[countryId]/government.tsx:158
 msgid "Announcements"
-msgstr ""
+msgstr "Обавештења"
 
 #: src/components/_political/law/law.frontConfig.tsx:282
 msgid "Another country proposed a defensive pact to yours"
@@ -1728,7 +1728,7 @@ msgstr "Да ли сте сигурни да желите да уклоните 
 
 #: src/components/_social/announcement/Announcement.tsx:133
 msgid "Are you sure you want to remove this announcement? Its comments will be deleted too."
-msgstr ""
+msgstr "Да ли си сигуран да желиш да уклониш ово обавештење? Биће обрисани и његови коментари."
 
 #: src/components/_user/mission/MissionItem.tsx:105
 msgid "Are you sure you want to reroll this mission? Your current progress will be lost."
@@ -1850,7 +1850,7 @@ msgstr "Напад"
 
 #: src/components/_user/user/MilitaryRank.tsx:111
 msgid "Attack bonus:"
-msgstr ""
+msgstr "Бонус напада:"
 
 #: src/components/_military/mercenaryContract/CreateAuctionModal.tsx:195
 #: src/components/_military/war/WarComparison.tsx:41
@@ -2012,7 +2012,7 @@ msgstr "Битка"
 
 #: src/components/_military/battle/MyBattlesRecapCard.tsx:166
 msgid "Battle by battle"
-msgstr ""
+msgstr "Приказ по биткама"
 
 #: src/pages/alliance/[allianceId]/index.tsx:41
 msgid "Battle damage bonus"
@@ -2045,7 +2045,7 @@ msgstr "Битка отворена"
 
 #: src/pages/country/[countryId]/government.tsx:137
 msgid "Battle orders"
-msgstr ""
+msgstr "Наређења"
 
 #: src/components/_military/battle/BattleSideOrdersModal.tsx:105
 msgid "Battle Orders"
@@ -3120,7 +3120,7 @@ msgstr "Нанеси <0>{count}</0> штете по наређењима зем�
 
 #: src/components/_user/user/MilitaryRank.tsx:85
 msgid "Deal <0>damages</0> in battles to climb the ranks!"
-msgstr ""
+msgstr "Наноси <0>штету</0> у биткама да напредујеш кроз чинове!"
 
 #: src/components/_user/user/MilitaryRanksInfoModal.tsx:94
 msgid "Deal damage in battles to increase your military rank and unlock attack bonuses."
@@ -3455,11 +3455,11 @@ msgstr "Спаваонице"
 
 #: src/components/_military/order/BattleOrderList.tsx:225
 msgid "Drag the new order to choose its number."
-msgstr ""
+msgstr "Превуци ново наређење да изабереш његов број."
 
 #: src/components/_military/order/BattleOrderList.tsx:227
 msgid "Drag the orders to change their priority number."
-msgstr ""
+msgstr "Превуци наређења да промениш њихов редослед приоритета."
 
 #: src/components/_other/shop/skin.frontConfig.tsx:155
 msgid "Dragon"
@@ -3471,7 +3471,7 @@ msgstr "е. Садржај о актуелним стварним ратовим
 
 #: src/components/_user/user/SkillUpgrade.tsx:293
 msgid "Each prestige point gives the equivalent of {skillBonusLevels} level of the selected skill"
-msgstr ""
+msgstr "Сваки поен престижа даје еквивалент {skillBonusLevels} нивоа изабране вештине"
 
 #: src/components/_user/mission/mission.frontConfig.tsx:141
 msgid "Eat"
@@ -3512,7 +3512,7 @@ msgstr "Економија и компаније"
 
 #: src/components/_military/battle/BattleOrderActionsDropdown.tsx:140
 msgid "Edit country order"
-msgstr ""
+msgstr "Измени наређење земље"
 
 #: src/components/_user/user/UserDropdown.tsx:231
 msgid "Edit description"
@@ -3524,7 +3524,7 @@ msgstr "Измени опис"
 
 #: src/components/_military/battle/BattleOrderActionsDropdown.tsx:149
 msgid "Edit MU order"
-msgstr ""
+msgstr "Измени наређење ВЈ"
 
 #: src/components/_user/worker/WorkerEditFormModal.tsx:154
 msgid "Edit worker"
@@ -3532,11 +3532,11 @@ msgstr "Измени радника"
 
 #: src/components/_military/battle/SetOrderFormModal.tsx:494
 msgid "Editing an existing order"
-msgstr ""
+msgstr "Измена постојећег наређења"
 
 #: src/components/_military/battle/SetOrderFormModal.tsx:492
 msgid "Editing another order"
-msgstr ""
+msgstr "Измена другог наређења"
 
 #: src/components/_user/user/SkillValue.tsx:260
 msgid "Effective:"
@@ -3724,7 +3724,7 @@ msgstr "Експанзионизам"
 
 #: src/components/_military/battle/MyBattlesRecapCard.tsx:221
 msgid "Expected loot"
-msgstr ""
+msgstr "Очекивани плен"
 
 #: src/components/_military/mercenaryContract/MercenaryAuctionItem.tsx:73
 #: src/components/_military/mercenaryContract/MercenaryContractItemContent.tsx:236
@@ -4672,7 +4672,7 @@ msgstr "Придружи се ВЈ"
 
 #: src/pages/index.tsx:139
 msgid "Join the world"
-msgstr ""
+msgstr "Придружи се свету"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:65
 msgid "Join this company!"
@@ -4956,7 +4956,7 @@ msgstr "Ограничење потрошње хране"
 
 #: src/components/_economy/company/CompanyList.tsx:178
 msgid "Limit reached"
-msgstr ""
+msgstr "Лимит достигнут"
 
 #: src/components/_user/user/SkillValue.tsx:118
 msgid "Limited:"
@@ -5002,7 +5002,7 @@ msgstr "Локација"
 
 #: src/components/_user/user/SkillUpgrade.tsx:289
 msgid "Locked, reset your skills to reassign"
-msgstr ""
+msgstr "Закључано — ресетуј вештине да поново распоредиш поене"
 
 #: src/components/_user/user/MyAvatar.tsx:60
 msgid "Logout"
@@ -5131,7 +5131,7 @@ msgstr "Максимум <0>{0}</0> радника.{1}"
 
 #: src/components/_user/user/MilitaryRank.tsx:93
 msgid "Maximum rank achieved!"
-msgstr ""
+msgstr "Достигнут је највиши чин!"
 
 #: src/components/_economy/inventory/case/cases.frontConfig.tsx:32
 msgid "Maybe epic music would help?"
@@ -5304,7 +5304,7 @@ msgstr "Војна јединица"
 
 #: src/components/_social/announcement/AnnouncementModal.tsx:49
 msgid "Military unit announcement"
-msgstr ""
+msgstr "Обавештење војне јединице"
 
 #: src/components/_military/mu/MuFormModal.tsx:46
 msgid "Military unit created"
@@ -5527,7 +5527,7 @@ msgstr "Име"
 
 #: src/components/_user/auth/CountryWelcomeArticle.tsx:50
 msgid "National article of<0/>"
-msgstr ""
+msgstr "Чланак добродошлице аутора <0/>"
 
 #: src/components/_political/party/party.frontConfig.tsx:425
 msgid "National battle orders cost double."
@@ -5643,7 +5643,7 @@ msgstr "Нова националност"
 
 #: src/components/_military/order/OrderBattleItem.tsx:96
 msgid "New order"
-msgstr ""
+msgstr "Ново наређење"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2034
 msgid "New Party Application"
@@ -5697,7 +5697,7 @@ msgstr "Следећи ће бити тенк"
 
 #: src/components/_user/user/SkillUpgrade.tsx:272
 msgid "Next point costs"
-msgstr ""
+msgstr "Следећи поен кошта"
 
 #: src/components/_military/mu/MuLevel.tsx:97
 msgid "Next reward"
@@ -5733,7 +5733,7 @@ msgstr "Нема активних понуда за посао"
 
 #: src/components/_military/order/BattleOrderList.tsx:155
 msgid "No active order"
-msgstr ""
+msgstr "Нема активног наређења"
 
 #: src/components/_political/country/CountryDiplomacyGrid.tsx:267
 msgid "No active wars"
@@ -5753,7 +5753,7 @@ msgstr "Још нема закона савеза"
 
 #: src/components/_social/announcement/AnnouncementList.tsx:57
 msgid "No announcement yet"
-msgstr ""
+msgstr "Још нема обавештења"
 
 #: src/components/_user/apiToken/ApiTokenList.tsx:231
 msgid "No API tokens yet. Create one to get started."
@@ -5857,7 +5857,7 @@ msgstr "Није пронађена ниједна странка"
 
 #: src/components/_user/user/SkillUpgrade.tsx:287
 msgid "No prestige points left, tap to reset staged points"
-msgstr ""
+msgstr "Нема преосталих поена престижа, притисни да поништиш распоређене поене"
 
 #: src/pages/country/[countryId]/index.tsx:382
 msgid "No production bonus from resources. This country has no specialization."
@@ -5953,7 +5953,7 @@ msgstr "Није постављено"
 
 #: src/components/_military/battle/MyBattlesRecapCard.tsx:158
 msgid "Nothing in play. Hit in an ongoing battle to start earning, and take a top damage rank to claim a spot in its loot pool."
-msgstr ""
+msgstr "Тренутно ништа није у игри. Удари у текућој бици да почнеш да зарађујеш и заузми једно од водећих места по нанетој штети да уђеш у расподелу њеног фонда плена."
 
 #: src/pages/notifications.tsx:38
 #: src/pages/user/[userId]/settings.tsx:79
@@ -6011,7 +6011,7 @@ msgstr "Мало је фалило за легендарно..."
 #: src/components/_military/battle/MyBattlesRecapCard.tsx:149
 #: src/components/_military/battle/MyBattlesRecapCard.tsx:153
 msgid "Ongoing battles"
-msgstr ""
+msgstr "Битке у току"
 
 #: src/components/_political/party/party.frontConfig.tsx:345
 #: src/components/_political/party/party.frontConfig.tsx:366
@@ -6118,7 +6118,7 @@ msgstr "Налози отказани"
 #: src/pages/orders.tsx:24
 #: src/pages/orders.tsx:35
 msgid "Orders of <0/>"
-msgstr ""
+msgstr "Наређења од <0/>"
 
 #: src/components/_military/battle/ActiveBattlesList.tsx:118
 #: src/components/_user/notification/notificationPrefs.categories.ts:161
@@ -6287,7 +6287,7 @@ msgstr "Налепи везу до чланка своје кампање или
 
 #: src/components/_user/user/Level.tsx:156
 msgid "Paused at max level"
-msgstr ""
+msgstr "Паузирано на највишем нивоу"
 
 #: src/pages/shop/index.tsx:45
 msgid "Payment successful! Thanks for supporting the game <3"
@@ -6355,7 +6355,7 @@ msgstr "Посади дрво у дата центру"
 
 #: src/pages/index.tsx:131
 msgid "Play now"
-msgstr ""
+msgstr "Играј сада"
 
 #: src/components/_common/GameRules.tsx:31
 msgid "Players are limited to a single account. Creating multiple accounts or using someone else's account for any reason is strictly prohibited."
@@ -6474,19 +6474,19 @@ msgstr "Председнички избори"
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:135
 #: src/pages/user/[userId]/skills.tsx:193
 msgid "Prestige"
-msgstr ""
+msgstr "Престиж"
 
 #: src/components/_user/user/Level.tsx:167
 msgid "Prestige to drop levels and re-activate your XP bonus."
-msgstr ""
+msgstr "Оствари престиж да изгубиш нивое и поново активираш свој XP бонус."
 
 #: src/components/_user/user/SkillValue.tsx:72
 msgid "Prestige:"
-msgstr ""
+msgstr "Престиж:"
 
 #: src/components/_user/notification/notification.frontConfig.tsx:2140
 msgid "Prestige!"
-msgstr ""
+msgstr "Престиж!"
 
 #: src/components/_economy/itemTrading/ItemTradingOrderFormModal.tsx:430
 msgid "Price auto-matches existing orders"
@@ -6763,7 +6763,7 @@ msgstr "Прочитај чланак"
 
 #: src/components/_user/auth/CountryWelcomeArticle.tsx:58
 msgid "Read the article"
-msgstr ""
+msgstr "Прочитај чланак"
 
 #: src/components/_other/tour/tuto.frontConfig.tsx:130
 msgid "Ready for battle!"
@@ -7618,7 +7618,7 @@ msgstr "Камење за праћку"
 
 #: src/components/_layout/LayoutOptions.tsx:187
 msgid "Small GIFs"
-msgstr ""
+msgstr "Мали GIF-ови"
 
 #: src/utils/translations.tsx:25
 msgid "Sniper"
@@ -7666,7 +7666,7 @@ msgstr "Стабилна снага отпорна на освајања. И д�
 
 #: src/components/_user/user/SkillUpgrade.tsx:268
 msgid "Stage a prestige point on this skill (applied on save, reset on skill reset)"
-msgstr ""
+msgstr "Распореди поен престижа на ову вештину (примењује се при чувању, поништава се при ресетовању вештина)"
 
 #: src/components/_political/law/law.frontConfig.tsx:169
 #: src/components/_political/law/law.frontConfig.tsx:171
@@ -8756,7 +8756,7 @@ msgstr "Верификуј"
 
 #: src/components/_user/auth/ConnectFromModal.tsx:295
 msgid "Verifying you're human..."
-msgstr ""
+msgstr "Проверавамо да ли си човек..."
 
 #: src/components/_user/user/militaryRankings.frontConfig.tsx:131
 msgid "Vice Admiral"
@@ -8778,7 +8778,7 @@ msgstr "Види на мапи"
 
 #: src/components/_social/announcement/Announcement.tsx:59
 msgid "Views"
-msgstr ""
+msgstr "Прегледи"
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:103
 msgid "Voter"
@@ -8909,7 +8909,7 @@ msgstr "Добродошао у твоју економију!"
 
 #: src/components/_military/battle/MyBattlesRecapCard.tsx:150
 msgid "What the battles you are fighting in have paid you so far (hits, damage, cases, bounty and contract money), plus the loot pool items you are currently in line for. Pool items are not won yet: they follow the damage rankings and are only yours once the pool is distributed."
-msgstr ""
+msgstr "Оно што су ти битке у којима учествујеш до сада донеле (ударци, штета, сандучићи, награде и новац од уговора), уз предмете из фонда плена за које си тренутно у реду. Предмети из фонда још нису освојени: додељују се према ранг-листи штете и постају твоји тек када се фонд расподели."
 
 #. placeholder {0}: formatPercent( ethicsBonuses.militarism[2].pacificationDefenseBonusPerLevel, )
 #: src/components/_political/party/party.frontConfig.tsx:116
@@ -9111,7 +9111,7 @@ msgstr "Довео си 10 беба на свет (>= ниво {0})"
 
 #: src/pages/index.tsx:126
 msgid "You can change it later."
-msgstr ""
+msgstr "Можеш то касније да промениш."
 
 #: src/components/_economy/inventory/DismantleModal.tsx:211
 msgid "You can dismantle items from your inventory by selecting an item."
@@ -9188,7 +9188,7 @@ msgstr "Конзумирао си <0>{0}</0>, ефекат почиње сада
 
 #: src/components/_user/notification/notification.frontConfig.tsx:1712
 msgid "You have prestiged! Enjoy your permanent XP bonus and prestige point."
-msgstr ""
+msgstr "Остварио си престиж! Уживај у трајном XP бонусу и поену престижа."
 
 #: src/pages/country/[countryId]/government.tsx:43
 msgid "You have resigned from the congress"
@@ -9269,7 +9269,7 @@ msgstr "Твој премијум поклон од <0/> је истекао! Д
 
 #: src/components/_user/badgeCollection/badgeCollection.frontConfig.tsx:136
 msgid "You prestiged and lost your levels"
-msgstr ""
+msgstr "Остварио си престиж и изгубио своје нивое"
 
 #. placeholder {0}: data.rank
 #: src/components/_user/notification/notification.frontConfig.tsx:1267
@@ -9358,7 +9358,7 @@ msgstr "Био си баш близу"
 
 #: src/pages/user/[userId]/skills.tsx:124
 msgid "You will drop to level 25 (losing 65,000 XP), gain a permanent +50% XP bonus (+10% per additional prestige level) and a prestige point, and your skills will be reset for free."
-msgstr ""
+msgstr "Пашћеш на ниво 25 (и изгубити 65.000 XP-а), добити трајни XP бонус од +50% (+10% за сваки додатни ниво престижа) и поен престижа, а твоје вештине ће бити бесплатно ресетоване."
 
 #. placeholder {0}: gameConfig?.referral.lifeTimeBadgeMoneySharePercent
 #: src/components/_user/referral/ReferralList.tsx:117
@@ -9435,7 +9435,7 @@ msgstr "Твоје обавештење земљи..."
 
 #: src/components/_social/announcement/AnnouncementFormModal.tsx:30
 msgid "Your announcement to the unit..."
-msgstr ""
+msgstr "Твоје обавештење јединици..."
 
 #: src/components/_user/notification/notification.frontConfig.tsx:368
 #: src/components/_user/notification/notification.frontConfig.tsx:1068


### PR DESCRIPTION
Updated the Serbian translation for v0.25.3-beta. All 53 missing strings in `sr/messages.po` are translated. Existing `msgid` values and placeholders were left unchanged.